### PR TITLE
docs + refactor: Sphinx extensions added + Documentation updated + Docstrings updated.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,7 +9,7 @@ max-complexity = 15
 max-line-length = 88
 statistics = True
 # Prevents some flake8-rst-docstrings errors
-rst-roles = attr,class,func,meth,mod,obj,ref,doc,exc,py:meth
+rst-roles = attr,class,func,meth,mod,obj,ref,doc,exc,py:meth,data
 rst-directives = manim, SEEALSO, seealso
 docstring-convention=numpy
 

--- a/.flake8
+++ b/.flake8
@@ -9,7 +9,7 @@ max-complexity = 15
 max-line-length = 88
 statistics = True
 # Prevents some flake8-rst-docstrings errors
-rst-roles = attr,class,func,meth,mod,obj,ref,doc,exc
+rst-roles = attr,class,func,meth,mod,obj,ref,doc,exc,py:meth
 rst-directives = manim, SEEALSO, seealso
 docstring-convention=numpy
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 manim
 furo
+sphinx-autodoc-typehints

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,12 +25,26 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
     "manim.utils.docbuild.manim_directive",
+    "sphinx.ext.napoleon",
+    "sphinx_autodoc_typehints",
 ]
 
 templates_path = ["_templates"]
 exclude_patterns = []
+
+# displays shorter function names that are documented via autodoc - sphinx.ext.autosummary
 add_module_names = False
+
+# displays type hint defaults - sphinx_autodoc_typehints
+typehints_defaults = "comma"
+
+# allows external documentation to be referred - sphinx.ext.intersphinx
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "manim": ("https://docs.manim.community/en/stable/", None),
+}
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
@@ -48,11 +62,4 @@ html_theme_options = {
     "top_of_page_button": None,
     "light_logo": "logo-color-no-bg.svg",
     "dark_logo": "logo-white-no-bg.svg",
-}
-
-# -- Options for Inter Sphinx ----------------------------------------------------
-
-intersphinx_mapping = {
-    "python": ("https://docs.python.org/3", None),
-    "manim": ("https://docs.manim.community/en/stable/", None),
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,11 +24,13 @@ extensions = [
     "sphinx.ext.duration",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
     "manim.utils.docbuild.manim_directive",
 ]
 
 templates_path = ["_templates"]
 exclude_patterns = []
+add_module_names = False
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
@@ -46,4 +48,11 @@ html_theme_options = {
     "top_of_page_button": None,
     "light_logo": "logo-color-no-bg.svg",
     "dark_logo": "logo-white-no-bg.svg",
+}
+
+# -- Options for Inter Sphinx ----------------------------------------------------
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "manim": ("https://docs.manim.community/en/stable/", None),
 }

--- a/docs/source/guides/arrays.rst
+++ b/docs/source/guides/arrays.rst
@@ -1,12 +1,12 @@
+.. include:: ../refsub.rst
+
 Animating Arrays
 ================
-
-.. currentmodule:: manim_data_structures
 
 Manim Array - MArray
 --------------------
 
-The most basic data structure this package provides is the :py:class:`~m_array.MArray` (short for Manim Array 😄). To create a :py:class:`~m_array.MArray` simply create an instance by passing a python :py:class:`list`.
+The most basic data structure this package provides is the |MArray| (short for Manim Array 😄). To create a |MArray| simply create an instance by passing a python |list|.
 
 .. code-block:: python
     :linenos:
@@ -36,7 +36,7 @@ The most basic data structure this package provides is the :py:class:`~m_array.M
 Animating MArray
 ~~~~~~~~~~~~~~~~
 
-To animate the :py:class:`~m_array.MArray`, simply invoke the :py:attr:`~manim.mobject.mobject.Mobject.animate` property as shown below:
+To animate the |MArray|, simply invoke the |Mobject.animate| property as shown below:
 
 .. code-block:: python
     :linenos:
@@ -60,7 +60,7 @@ To animate the :py:class:`~m_array.MArray`, simply invoke the :py:attr:`~manim.m
             self.play(arr.animate.shift(UP * 2 + LEFT * 5))
             self.wait(1)
 
-Moreover, you can also use the :py:meth:`MArray.animate_elem() <m_array.MArray.animate_elem>` method to animate a single element of the :py:class:`~m_array.MArray` as well:
+Moreover, you can also use the |MArray.animate_elem| method to animate a single element of the |MArray| as well:
 
 .. code-block:: python
     :linenos:
@@ -84,7 +84,7 @@ Moreover, you can also use the :py:meth:`MArray.animate_elem() <m_array.MArray.a
             self.play(arr.animate_elem(1).shift(DOWN))
             self.wait(1)
 
-Lastly, you can also animate the body, value and the index of any element using the :py:meth:`MArray.animate_elem_square() <m_array.MArray.animate_elem_square>`, :py:meth:`MArray.animate_elem_value() <m_array.MArray.animate_elem_value>` and :py:meth:`MArray.animate_elem_index() <m_array.MArray.animate_elem_index>` respectively.
+Lastly, you can also animate the body, value and the index of any element using the |MArray.animate_elem_square|, |MArray.animate_elem_value| and |MArray.animate_elem_index| respectively.
 
 .. code-block:: python
     :linenos:
@@ -119,7 +119,7 @@ Lastly, you can also animate the body, value and the index of any element using 
 Customizing MArray
 ~~~~~~~~~~~~~~~~~~
 
-The :py:class:`~m_array.MArray` also allows you to alter the way your array looks. While creating your array pass arguments to :py:class:`~manim.mobject.geometry.polygram.Square` (used to represent the element body) and :py:class:`~manim.mobject.text.text_mobject.Text` (used to represent the element value and index) mobjects.
+The |MArray| also allows you to alter the way your array looks. While creating your array pass arguments to |Square| (used to represent the element body) and |Text| (used to represent the element value and index) mobjects.
 
 .. code-block:: python
     :linenos:
@@ -157,9 +157,9 @@ The :py:class:`~m_array.MArray` also allows you to alter the way your array look
 Growth Direction
 ^^^^^^^^^^^^^^^^
 
-Furthermore, you can also create :py:class:`~m_array.MArray` that grows in different directions (e.g. up, down, right and left etc.).
+Furthermore, you can also create |MArray| that grows in different directions (e.g. up, down, right and left etc.).
 
-To do this, simply pass your preferred direction enum from :py:class:`~m_enum.MArrayDirection` as the ``arr_dir`` argument to the constructor. The code snippet below generates four different arrays in each direction.
+To do this, simply pass your preferred direction enum from |MArrayDirection| as the ``arr_dir`` argument to the constructor. The code snippet below generates four different arrays in each direction.
 
 .. code-block:: python
     :linenos:
@@ -213,9 +213,9 @@ To do this, simply pass your preferred direction enum from :py:class:`~m_enum.MA
 Array Label
 ^^^^^^^^^^^
 
-For an :py:class:`~m_array.MArray`, you can also a label with the array via specifying the ``label`` argument.
+For an |MArray|, you can also a label with the array via specifying the ``label`` argument.
 
-Similar to how we specify the growth direction using :py:class:`~m_enum.MArrayDirection` enum, we can dictate the position of the label.
+Similar to how we specify the growth direction using |MArrayDirection| enum, we can dictate the position of the label.
 
 .. code-block:: python
     :linenos:
@@ -268,12 +268,12 @@ Similar to how we specify the growth direction using :py:class:`~m_enum.MArrayDi
 
 .. note::
 
-    The ``arr_label_gap`` argument specifies the distance between the :py:class:`~m_array.MArrayElement` 's :py:class:`~manim.mobject.geometry.polygram.Square` and the array label itself.
+    The ``arr_label_gap`` argument specifies the distance between the |MArrayElement| 's |Square| and the array label itself.
 
 Hex Indices
 ^^^^^^^^^^^
 
-Lets say you want to show a 4-byte integer array with its addresses. You can simply achieve this by using ``index_hex_display`` and ``index_offset`` arguments of the :py:class:`~m_array.MArray` constructor.
+Lets say you want to show a 4-byte integer array with its addresses. You can simply achieve this by using ``index_hex_display`` and ``index_offset`` arguments of the |MArray| constructor.
 
 .. code-block:: python
     :linenos:
@@ -351,12 +351,12 @@ Or if you don't want to show the indices at all, simply pass ``True`` as the ``h
 Misc Functions
 ~~~~~~~~~~~~~~
 
-The :py:class:`~m_array.MArray` provides some auxiliary methods which this secion will discuss.
+The |MArray| provides some auxiliary methods which this secion will discuss.
 
 Append Element
 ^^^^^^^^^^^^^^
 
-For an existing array, you can also append an element simply by invoking the :py:meth:`MArray.append_elem() <m_array.MArray.append_elem>` method.
+For an existing array, you can also append an element simply by invoking the |MArray.append_elem| method.
 
 .. code-block:: python
     :linenos:
@@ -391,7 +391,7 @@ For an existing array, you can also append an element simply by invoking the :py
 
     You can also pass ``mob_*_args`` to this method to customize the inserted element.
 
-Moreover, you can also specify the animation that is played for the inserted element via the ``append_anim`` argument. The code snippet below passes the :py:class:`~manim.animation.growing.GrowFromCenter` animation to the :py:meth:`MArray.append_elem() <m_array.MArray.append_elem>` method:
+Moreover, you can also specify the animation that is played for the inserted element via the ``append_anim`` argument. The code snippet below passes the |GrowFromCenter| animation to the |MArray.append_elem| method:
 
 .. code-block:: python
     :linenos:
@@ -418,11 +418,11 @@ Moreover, you can also specify the animation that is played for the inserted ele
 
 .. note::
 
-    You can also specify arguments to the passed animation via the ``append_anim_args`` parameter and also set the target of the animation using the ``append_anim_target`` parameter that takes in :py:class:`~m_enum.MArrayElementComp` enum.
+    You can also specify arguments to the passed animation via the ``append_anim_args`` parameter and also set the target of the animation using the ``append_anim_target`` parameter that takes in |MArrayElementComp| enum.
 
-Did you notice that in both snippets, we didn't pass any animation to our :py:class:`~manim.scene.scene.Scene` but the append animation still played? This is thanks to the ``self`` that we pass as the first argument to our :py:class:`~m_array.MArray` constructor, which is basically a reference to the current :py:class:`~manim.scene.scene.Scene`.
+Did you notice that in both snippets, we didn't pass any animation to our |Scene| but the append animation still played? This is thanks to the ``self`` that we pass as the first argument to our |MArray| constructor, which is basically a reference to the current |Scene|.
 
-However, if you'd like to play the animation yourself, we have got you covered! The :py:class:`~m_array.MArrayElement` method returns a list of :py:class:`~manim.animation.animation.Animation` that you can pass to the :py:meth:`Scene.play() <manim.scene.scene.Scene.play>` method as follows:
+However, if you'd like to play the animation yourself, we have got you covered! The |MArrayElement| method returns a list of |Animation| that you can pass to the |Scene.play| method as follows:
 
 .. code-block:: python
     :linenos:
@@ -432,7 +432,7 @@ However, if you'd like to play the animation yourself, we have got you covered! 
 Remove Element
 ^^^^^^^^^^^^^^
 
-To remove an element simply invoke the :py:meth:`MArray.remove_elem() <m_array.MArray.remove_elem>` method with the index of element you wish to remove.
+To remove an element simply invoke the |MArray.remove_elem| method with the index of element you wish to remove.
 
 .. code-block:: python
     :linenos:
@@ -457,7 +457,7 @@ To remove an element simply invoke the :py:meth:`MArray.remove_elem() <m_array.M
             arr.remove_elem(1)
             self.wait(1)
 
-Similar to how you were able to pass the append animation to the :py:meth:`MArray.append_elem() <m_array.MArray.append_elem>` function, you can specify two animations for the :py:meth:`MArray.remove_elem() <m_array.MArray.remove_elem>` method:
+Similar to how you were able to pass the append animation to the |MArray.append_elem| function, you can specify two animations for the |MArray.remove_elem| method:
 
 1. Element removal animation via the ``removal_anim`` parameter.
 2. Indices update animation via the ``update_anim`` parameter.
@@ -491,7 +491,7 @@ The code snippet below provides an example:
 
     You can also specify arguments to the passed animation via the ``*_anim_args`` parameter and also set the target of the animation using the ``*_anim_target`` parameter.
 
-Lastly, as the :py:meth:`MArray.append_elem() <m_array.MArray.append_elem>` returns a list of :py:class:`~manim.animation.animation.Animation`, the :py:meth:`MArray.remove_elem() <m_array.MArray.remove_elem>` returns two objects; a removal animation and a function that udpates the indices of the remaining elements and returns their animations. Hence, you can animate this as follows:
+Lastly, as the |MArray.append_elem| returns a list of |Animation|, the |MArray.remove_elem| returns two objects; a removal animation and a function that udpates the indices of the remaining elements and returns their animations. Hence, you can animate this as follows:
 
 .. code-block:: python
     :linenos:
@@ -503,7 +503,7 @@ Lastly, as the :py:meth:`MArray.append_elem() <m_array.MArray.append_elem>` retu
 Update Element
 ^^^^^^^^^^^^^^
 
-You can also update the value and the index of an existing array using the :py:meth:`MArray.update_elem_value() <m_array.MArray.update_elem_value>` and :py:meth:`MArray.update_elem_index() <m_array.MArray.update_elem_index>` methods respectively.
+You can also update the value and the index of an existing array using the |MArray.update_elem_value| and |MArray.update_elem_index| methods respectively.
 
 .. code-block:: python
     :linenos:
@@ -543,7 +543,7 @@ You can also update the value and the index of an existing array using the :py:m
 Using MArrayPointer
 ~~~~~~~~~~~~~~~~~~~
 
-Thus far, if you had been hoping for a pointer to associate with your array, then your prayers have been answered. The :py:class:`~m_array.MArrayPointer` allows you to attach a pointer with your array. The following snippet demonstrates its capabilities:
+Thus far, if you had been hoping for a pointer to associate with your array, then your prayers have been answered. The |MArrayPointer| allows you to attach a pointer with your array. The following snippet demonstrates its capabilities:
 
 .. code-block:: python
     :linenos:

--- a/docs/source/guides/arrays.rst
+++ b/docs/source/guides/arrays.rst
@@ -60,7 +60,7 @@ To animate the :py:class:`~m_array.MArray`, simply invoke the :py:attr:`~manim.m
             self.play(arr.animate.shift(UP * 2 + LEFT * 5))
             self.wait(1)
 
-Moreover, you can also use the :py:func:`MArray.animate_elem() <m_array.MArray.animate_elem>` method to animate a single element of the :py:class:`~m_array.MArray` as well:
+Moreover, you can also use the :py:meth:`MArray.animate_elem() <m_array.MArray.animate_elem>` method to animate a single element of the :py:class:`~m_array.MArray` as well:
 
 .. code-block:: python
     :linenos:
@@ -84,7 +84,7 @@ Moreover, you can also use the :py:func:`MArray.animate_elem() <m_array.MArray.a
             self.play(arr.animate_elem(1).shift(DOWN))
             self.wait(1)
 
-Lastly, you can also animate the body, value and the index of any element using the :py:func:`MArray.animate_elem_square() <m_array.MArray.animate_elem_square>`, :py:func:`MArray.animate_elem_value() <m_array.MArray.animate_elem_value>` and :py:func:`MArray.animate_elem_index() <m_array.MArray.animate_elem_index>` respectively.
+Lastly, you can also animate the body, value and the index of any element using the :py:meth:`MArray.animate_elem_square() <m_array.MArray.animate_elem_square>`, :py:meth:`MArray.animate_elem_value() <m_array.MArray.animate_elem_value>` and :py:meth:`MArray.animate_elem_index() <m_array.MArray.animate_elem_index>` respectively.
 
 .. code-block:: python
     :linenos:
@@ -356,7 +356,7 @@ The :py:class:`~m_array.MArray` provides some auxiliary methods which this secio
 Append Element
 ^^^^^^^^^^^^^^
 
-For an existing array, you can also append an element simply by invoking the :py:func:`MArray.append_elem() <m_array.MArray.append_elem>` method.
+For an existing array, you can also append an element simply by invoking the :py:meth:`MArray.append_elem() <m_array.MArray.append_elem>` method.
 
 .. code-block:: python
     :linenos:
@@ -391,7 +391,7 @@ For an existing array, you can also append an element simply by invoking the :py
 
     You can also pass ``mob_*_args`` to this method to customize the inserted element.
 
-Moreover, you can also specify the animation that is played for the inserted element via the ``append_anim`` argument. The code snippet below passes the :py:class:`~manim.animation.growing.GrowFromCenter` animation to the :py:func:`MArray.append_elem() <m_array.MArray.append_elem>` method:
+Moreover, you can also specify the animation that is played for the inserted element via the ``append_anim`` argument. The code snippet below passes the :py:class:`~manim.animation.growing.GrowFromCenter` animation to the :py:meth:`MArray.append_elem() <m_array.MArray.append_elem>` method:
 
 .. code-block:: python
     :linenos:
@@ -422,7 +422,7 @@ Moreover, you can also specify the animation that is played for the inserted ele
 
 Did you notice that in both snippets, we didn't pass any animation to our :py:class:`~manim.scene.scene.Scene` but the append animation still played? This is thanks to the ``self`` that we pass as the first argument to our :py:class:`~m_array.MArray` constructor, which is basically a reference to the current :py:class:`~manim.scene.scene.Scene`.
 
-However, if you'd like to play the animation yourself, we have got you covered! The :py:class:`~m_array.MArrayElement` method returns a list of :py:class:`~manim.animation.animation.Animation` that you can pass to the :py:func:`Scene.play() <manim.scene.scene.Scene.play>` method as follows:
+However, if you'd like to play the animation yourself, we have got you covered! The :py:class:`~m_array.MArrayElement` method returns a list of :py:class:`~manim.animation.animation.Animation` that you can pass to the :py:meth:`Scene.play() <manim.scene.scene.Scene.play>` method as follows:
 
 .. code-block:: python
     :linenos:
@@ -432,7 +432,7 @@ However, if you'd like to play the animation yourself, we have got you covered! 
 Remove Element
 ^^^^^^^^^^^^^^
 
-To remove an element simply invoke the :py:func:`MArray.remove_elem() <m_array.MArray.remove_elem>` method with the index of element you wish to remove.
+To remove an element simply invoke the :py:meth:`MArray.remove_elem() <m_array.MArray.remove_elem>` method with the index of element you wish to remove.
 
 .. code-block:: python
     :linenos:
@@ -457,7 +457,7 @@ To remove an element simply invoke the :py:func:`MArray.remove_elem() <m_array.M
             arr.remove_elem(1)
             self.wait(1)
 
-Similar to how you were able to pass the append animation to the :py:func:`MArray.append_elem() <m_array.MArray.append_elem>` function, you can specify two animations for the :py:func:`MArray.remove_elem() <m_array.MArray.remove_elem>` method:
+Similar to how you were able to pass the append animation to the :py:meth:`MArray.append_elem() <m_array.MArray.append_elem>` function, you can specify two animations for the :py:meth:`MArray.remove_elem() <m_array.MArray.remove_elem>` method:
 
 1. Element removal animation via the ``removal_anim`` parameter.
 2. Indices update animation via the ``update_anim`` parameter.
@@ -491,7 +491,7 @@ The code snippet below provides an example:
 
     You can also specify arguments to the passed animation via the ``*_anim_args`` parameter and also set the target of the animation using the ``*_anim_target`` parameter.
 
-Lastly, as the :py:func:`MArray.append_elem() <m_array.MArray.append_elem>` returns a list of :py:class:`~manim.animation.animation.Animation`, the :py:func:`MArray.remove_elem() <m_array.MArray.remove_elem>` returns two objects; a removal animation and a function that udpates the indices of the remaining elements and returns their animations. Hence, you can animate this as follows:
+Lastly, as the :py:meth:`MArray.append_elem() <m_array.MArray.append_elem>` returns a list of :py:class:`~manim.animation.animation.Animation`, the :py:meth:`MArray.remove_elem() <m_array.MArray.remove_elem>` returns two objects; a removal animation and a function that udpates the indices of the remaining elements and returns their animations. Hence, you can animate this as follows:
 
 .. code-block:: python
     :linenos:
@@ -503,7 +503,7 @@ Lastly, as the :py:func:`MArray.append_elem() <m_array.MArray.append_elem>` retu
 Update Element
 ^^^^^^^^^^^^^^
 
-You can also update the value and the index of an existing array using the :py:func:`MArray.update_elem_value() <m_array.MArray.update_elem_value>` and :py:func:`MArray.update_elem_index() <m_array.MArray.update_elem_index>` methods respectively.
+You can also update the value and the index of an existing array using the :py:meth:`MArray.update_elem_value() <m_array.MArray.update_elem_value>` and :py:meth:`MArray.update_elem_index() <m_array.MArray.update_elem_index>` methods respectively.
 
 .. code-block:: python
     :linenos:

--- a/docs/source/guides/arrays.rst
+++ b/docs/source/guides/arrays.rst
@@ -1,12 +1,12 @@
 Animating Arrays
 ================
 
-.. currentmodule:: manim_data_structures.m_array
+.. currentmodule:: manim_data_structures
 
 Manim Array - MArray
 --------------------
 
-The most basic data structure this package provides is the :py:class:`MArray` (short for Manim Array 😄). To create a :py:class:`MArray` simply create an instance by passing a python :py:class:`list`.
+The most basic data structure this package provides is the :py:class:`~m_array.MArray` (short for Manim Array 😄). To create a :py:class:`~m_array.MArray` simply create an instance by passing a python :py:class:`list`.
 
 .. code-block:: python
     :linenos:
@@ -36,7 +36,7 @@ The most basic data structure this package provides is the :py:class:`MArray` (s
 Animating MArray
 ~~~~~~~~~~~~~~~~
 
-To animate the :py:class:`MArray`, simply invoke the ``animate`` property as shown below:
+To animate the :py:class:`~m_array.MArray`, simply invoke the :py:attr:`~manim.mobject.mobject.Mobject.animate` property as shown below:
 
 .. code-block:: python
     :linenos:
@@ -60,7 +60,7 @@ To animate the :py:class:`MArray`, simply invoke the ``animate`` property as sho
             self.play(arr.animate.shift(UP * 2 + LEFT * 5))
             self.wait(1)
 
-Moreover, you can also use the :py:func:`MArray.animate_elem` method to animate a single element of the :py:class:`MArray` as well:
+Moreover, you can also use the :py:func:`MArray.animate_elem() <m_array.MArray.animate_elem>` method to animate a single element of the :py:class:`~m_array.MArray` as well:
 
 .. code-block:: python
     :linenos:
@@ -84,7 +84,7 @@ Moreover, you can also use the :py:func:`MArray.animate_elem` method to animate 
             self.play(arr.animate_elem(1).shift(DOWN))
             self.wait(1)
 
-Lastly, you can also animate the body, value and the index of any element using the :py:func:`MArray.animate_elem_square`, :py:func:`MArray.animate_elem_value` and :py:func:`MArray.animate_elem_index` respectively.
+Lastly, you can also animate the body, value and the index of any element using the :py:func:`MArray.animate_elem_square() <m_array.MArray.animate_elem_square>`, :py:func:`MArray.animate_elem_value() <m_array.MArray.animate_elem_value>` and :py:func:`MArray.animate_elem_index() <m_array.MArray.animate_elem_index>` respectively.
 
 .. code-block:: python
     :linenos:
@@ -119,7 +119,7 @@ Lastly, you can also animate the body, value and the index of any element using 
 Customizing MArray
 ~~~~~~~~~~~~~~~~~~
 
-The :py:class:`MArray` also allows you to alter the way your array looks. While creating your array pass arguments to ``Square`` (used to represent the element body) and ``Text`` (used to represent the element value and index) mobjects.
+The :py:class:`~m_array.MArray` also allows you to alter the way your array looks. While creating your array pass arguments to :py:class:`~manim.mobject.geometry.polygram.Square` (used to represent the element body) and :py:class:`~manim.mobject.text.text_mobject.Text` (used to represent the element value and index) mobjects.
 
 .. code-block:: python
     :linenos:
@@ -157,11 +157,9 @@ The :py:class:`MArray` also allows you to alter the way your array looks. While 
 Growth Direction
 ^^^^^^^^^^^^^^^^
 
-Furthermore, you can also create :py:class:`MArray` that grows in different directions (e.g. up, down, right and left etc.).
+Furthermore, you can also create :py:class:`~m_array.MArray` that grows in different directions (e.g. up, down, right and left etc.).
 
-.. currentmodule:: manim_data_structures.m_enum
-
-To do this, simply pass your preferred direction enum from :py:class:`MArrayDirection` as the ``arr_dir`` argument to the constructor. The code snippet below generates four different arrays in each direction.
+To do this, simply pass your preferred direction enum from :py:class:`~m_enum.MArrayDirection` as the ``arr_dir`` argument to the constructor. The code snippet below generates four different arrays in each direction.
 
 .. code-block:: python
     :linenos:
@@ -215,13 +213,9 @@ To do this, simply pass your preferred direction enum from :py:class:`MArrayDire
 Array Label
 ^^^^^^^^^^^
 
-.. currentmodule:: manim_data_structures.m_array
+For an :py:class:`~m_array.MArray`, you can also a label with the array via specifying the ``label`` argument.
 
-For an :py:class:`MArray`, you can also a label with the array via specifying the ``label`` argument.
-
-.. currentmodule:: manim_data_structures.m_enum
-
-Similar to how we specify the growth direction using :py:class:`MArrayDirection` enum, we can dictate the position of the label.
+Similar to how we specify the growth direction using :py:class:`~m_enum.MArrayDirection` enum, we can dictate the position of the label.
 
 .. code-block:: python
     :linenos:
@@ -272,16 +266,14 @@ Similar to how we specify the growth direction using :py:class:`MArrayDirection`
 
             self.wait(1)
 
-.. currentmodule:: manim_data_structures.m_array
-
 .. note::
 
-    The ``arr_label_gap`` argument specifies the distance between the :py:class:`MArrayElement` 's :py:class:`manim.Square` and the array label itself.
+    The ``arr_label_gap`` argument specifies the distance between the :py:class:`~m_array.MArrayElement` 's :py:class:`~manim.mobject.geometry.polygram.Square` and the array label itself.
 
 Hex Indices
 ^^^^^^^^^^^
 
-Lets say you want to show a 4-byte integer array with its addresses. You can simply achieve this by using ``index_hex_display`` and ``index_offset`` arguments of the :py:class:`MArray` constructor.
+Lets say you want to show a 4-byte integer array with its addresses. You can simply achieve this by using ``index_hex_display`` and ``index_offset`` arguments of the :py:class:`~m_array.MArray` constructor.
 
 .. code-block:: python
     :linenos:
@@ -359,12 +351,12 @@ Or if you don't want to show the indices at all, simply pass ``True`` as the ``h
 Misc Functions
 ~~~~~~~~~~~~~~
 
-The :py:class:`MArray` provides some auxiliary methods which this secion will discuss.
+The :py:class:`~m_array.MArray` provides some auxiliary methods which this secion will discuss.
 
 Append Element
 ^^^^^^^^^^^^^^
 
-For an existing array, you can also append an element simply by invoking the :py:func:`MArray.append_elem` method.
+For an existing array, you can also append an element simply by invoking the :py:func:`MArray.append_elem() <m_array.MArray.append_elem>` method.
 
 .. code-block:: python
     :linenos:
@@ -399,7 +391,7 @@ For an existing array, you can also append an element simply by invoking the :py
 
     You can also pass ``mob_*_args`` to this method to customize the inserted element.
 
-Moreover, you can also specify the animation that is played for the inserted element via the ``append_anim`` argument. The code snippet below passes the :py:class:`manim.GrowFromCenter` animation to the :py:func:`MArray.append_elem` method:
+Moreover, you can also specify the animation that is played for the inserted element via the ``append_anim`` argument. The code snippet below passes the :py:class:`~manim.animation.growing.GrowFromCenter` animation to the :py:func:`MArray.append_elem() <m_array.MArray.append_elem>` method:
 
 .. code-block:: python
     :linenos:
@@ -424,15 +416,13 @@ Moreover, you can also specify the animation that is played for the inserted ele
             arr.append_elem(4, append_anim=GrowFromCenter)
             self.wait(1)
 
-.. currentmodule:: manim_data_structures.m_enum
-
 .. note::
 
-    You can also specify arguments to the passed animation via the ``append_anim_args`` parameter and also set the target of the animation using the ``append_anim_target`` parameter that takes in :py:class:`MArrayElementComp` enum.
+    You can also specify arguments to the passed animation via the ``append_anim_args`` parameter and also set the target of the animation using the ``append_anim_target`` parameter that takes in :py:class:`~m_enum.MArrayElementComp` enum.
 
-Did you notice that in both snippets, we didn't pass any animation to our :py:class:`manim.Scene` but the append animation still played? This is thanks to the ``self`` that we pass as the first argument to our :py:class:`MArray` constructor, which is basically a reference to the current :py:class:`manim.Scene`.
+Did you notice that in both snippets, we didn't pass any animation to our :py:class:`~manim.scene.scene.Scene` but the append animation still played? This is thanks to the ``self`` that we pass as the first argument to our :py:class:`~m_array.MArray` constructor, which is basically a reference to the current :py:class:`~manim.scene.scene.Scene`.
 
-However, if you'd like to play the animation yourself, we have got you covered! The :py:func:`MArrayElement` method returns a list of :py:class:`manim.Animation` that you can pass to the :py:func:`manim.Scene.play` method as follows:
+However, if you'd like to play the animation yourself, we have got you covered! The :py:class:`~m_array.MArrayElement` method returns a list of :py:class:`~manim.animation.animation.Animation` that you can pass to the :py:func:`Scene.play() <manim.scene.scene.Scene.play>` method as follows:
 
 .. code-block:: python
     :linenos:
@@ -442,9 +432,7 @@ However, if you'd like to play the animation yourself, we have got you covered! 
 Remove Element
 ^^^^^^^^^^^^^^
 
-.. currentmodule:: manim_data_structures.m_array
-
-To remove an element simply invoke the :py:class:`MArray.remove_elem` method with the index of element you wish to remove.
+To remove an element simply invoke the :py:func:`MArray.remove_elem() <m_array.MArray.remove_elem>` method with the index of element you wish to remove.
 
 .. code-block:: python
     :linenos:
@@ -469,7 +457,7 @@ To remove an element simply invoke the :py:class:`MArray.remove_elem` method wit
             arr.remove_elem(1)
             self.wait(1)
 
-Similar to how you were able to pass the append animation to the :py:class:`MArray.append_elem` function, you can specify two animations for the :py:class:`MArray.remove_elem` method:
+Similar to how you were able to pass the append animation to the :py:func:`MArray.append_elem() <m_array.MArray.append_elem>` function, you can specify two animations for the :py:func:`MArray.remove_elem() <m_array.MArray.remove_elem>` method:
 
 1. Element removal animation via the ``removal_anim`` parameter.
 2. Indices update animation via the ``update_anim`` parameter.
@@ -503,7 +491,7 @@ The code snippet below provides an example:
 
     You can also specify arguments to the passed animation via the ``*_anim_args`` parameter and also set the target of the animation using the ``*_anim_target`` parameter.
 
-Lastly, as the :py:func:`MArray.append_elem` returns a list of :py:class:`manim.Animation`, the :py:func:`MArray.remove_elem` returns two objects; a removal animation and a function that udpates the indices of the remaining elements and returns their animations. Hence, you can animate this as follows:
+Lastly, as the :py:func:`MArray.append_elem() <m_array.MArray.append_elem>` returns a list of :py:class:`~manim.animation.animation.Animation`, the :py:func:`MArray.remove_elem() <m_array.MArray.remove_elem>` returns two objects; a removal animation and a function that udpates the indices of the remaining elements and returns their animations. Hence, you can animate this as follows:
 
 .. code-block:: python
     :linenos:
@@ -515,7 +503,7 @@ Lastly, as the :py:func:`MArray.append_elem` returns a list of :py:class:`manim.
 Update Element
 ^^^^^^^^^^^^^^
 
-You can also update the value and the index of an existing array using the :py:class:`MArray.update_elem_value` and :py:class:`MArray.update_elem_index` methods respectively.
+You can also update the value and the index of an existing array using the :py:func:`MArray.update_elem_value() <m_array.MArray.update_elem_value>` and :py:func:`MArray.update_elem_index() <m_array.MArray.update_elem_index>` methods respectively.
 
 .. code-block:: python
     :linenos:
@@ -555,7 +543,7 @@ You can also update the value and the index of an existing array using the :py:c
 Using MArrayPointer
 ~~~~~~~~~~~~~~~~~~~
 
-Thus far, if you had been hoping for a pointer to associate with your array, then your prayers have been answered. The :class:`MArrayPointer` allows you to attach a pointer with your array. The following snippet demonstrates its capabilities:
+Thus far, if you had been hoping for a pointer to associate with your array, then your prayers have been answered. The :py:class:`~m_array.MArrayPointer` allows you to attach a pointer with your array. The following snippet demonstrates its capabilities:
 
 .. code-block:: python
     :linenos:

--- a/docs/source/refsub.rst
+++ b/docs/source/refsub.rst
@@ -1,0 +1,28 @@
+.. currentmodule:: manim_data_structures
+
+.. Manim Data Structures substitutions
+.. |MArray| replace:: :py:class:`~m_array.MArray`
+.. |MArray.animate_elem| replace:: :py:meth:`MArray.animate_elem() <m_array.MArray.animate_elem>`
+.. |MArray.animate_elem_square| replace:: :py:meth:`MArray.animate_elem_square() <m_array.MArray.animate_elem_square>`
+.. |MArray.animate_elem_value| replace:: :py:meth:`MArray.animate_elem_value() <m_array.MArray.animate_elem_value>`
+.. |MArray.animate_elem_index| replace:: :py:meth:`MArray.animate_elem_index() <m_array.MArray.animate_elem_index>`
+.. |MArray.append_elem| replace:: :py:meth:`MArray.append_elem() <m_array.MArray.append_elem>`
+.. |MArray.remove_elem| replace:: :py:meth:`MArray.remove_elem() <m_array.MArray.remove_elem>`
+.. |MArray.update_elem_value| replace:: :py:meth:`MArray.update_elem_value() <m_array.MArray.update_elem_value>`
+.. |MArray.update_elem_index| replace:: :py:meth:`MArray.update_elem_index() <m_array.MArray.update_elem_index>`
+.. |MArrayElement| replace:: :py:class:`~m_array.MArrayElement`
+.. |MArrayDirection| replace:: :py:class:`~m_enum.MArrayDirection`
+.. |MArrayElementComp| replace:: :py:class:`~m_enum.MArrayElementComp`
+.. |MArrayPointer| replace:: :py:class:`~m_array.MArrayPointer`
+
+.. Manim substitutions
+.. |Mobject.animate| replace:: :py:attr:`~manim.mobject.mobject.Mobject.animate`
+.. |Scene| replace:: :py:class:`~manim.scene.scene.Scene`
+.. |Scene.play| replace:: :py:meth:`Scene.play() <manim.scene.scene.Scene.play>`
+.. |Square| replace:: :py:class:`~manim.mobject.geometry.polygram.Square`
+.. |Text| replace:: :py:class:`~manim.mobject.text.text_mobject.Text`
+.. |Animation| replace:: :py:class:`~manim.animation.animation.Animation`
+.. |GrowFromCenter| replace:: :py:class:`~manim.animation.growing.GrowFromCenter`
+
+.. Python substitutions
+.. |list| replace:: :py:class:`list`

--- a/src/manim_data_structures/m_array.py
+++ b/src/manim_data_structures/m_array.py
@@ -943,7 +943,7 @@ class MArray(VGroup):
         arr
             Specifies the array to represent.
         label
-            Specifies the label of the array.
+            Specifies the value of the array label.
         index_offset
             Specifies the difference between successive displayable indices.
         index_start
@@ -1063,7 +1063,7 @@ class MArray(VGroup):
         arr
             Specifies the array to represent.
         label
-            Specifies the label of the array.
+            Specifies the value of the array label.
         index_offset
             Specifies the difference between successive displayable indices.
         index_start
@@ -1512,53 +1512,57 @@ class MArrayPointer(VGroup):
 
     Parameters
     ----------
-    scene : :class:`manim.Scene`
-        The scene where the object should exist.
-    arr : typing.List[:class:`MArray`]
-        Array to attach the pointer to.
-    index : :class:`int`, default = `0`
-        Index of the array to attach the pointer to.
-    label : :class:`str`, default: `''`
-        Specifies the label of the pointer.
-    arrow_len : :class:`float`, default: `1`
-        Specifies the length of the arrow.
-    arrow_gap : :class:`float`, default: `0.25`
-        Specifies the distance between the array and the arrow head.
-    label_gap : :class:`float`, default: `0.25`
-        Specifies the distance betweem the label and the arrow tail.
-    pointer_pos : :class:`.m_enum.MArrayDirection`, default: :attr:`.m_enum.MArrayDirection.DOWN`
-        Specifies the poistion of the pointer w.r.t the array.
-    mob_arrow_args : :class:`dict`, default: `{}`
-        Arguments for :class:`manim.Arrow` that represents the arrow for :class:`MArrayPointer`.
-    mob_label_args : :class:`dict`, default: `{}`
-        Arguments for :class:`manim.Text` that represents the label for :class:`MArrayPointer`.
+    scene
+        Specifies the scene where the object is to be rendered.
+    arr
+        Specifies the array to which the pointer is to be attached.
+    index
+        Specifies the index of the element to which the pointer is to be attached.
+    label
+        Specifies the value of the pointer label.
+    arrow_len
+        Specifies the length of :attr:`__mob_arrow`.
+    arrow_gap
+        Specifies the distance between :attr:`__mob_arrow` and :attr:`__arr`.
+    label_gap
+        Specifies the distance between :attr:`__mob_arrow` and :attr:`__mob_label`.
+    pointer_pos
+        Specifies the position of the pointer w.r.t to :attr:`__arr`.
+    mob_arrow_args
+        Arguments for :class:`~manim.mobject.geometry.line.Arrow` that represents the pointer arrow.
+    mob_label_args
+        Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the pointer label.
     **kwargs
         Forwarded to constructor of the parent.
 
     Attributes
     ----------
-    __scene : :class:`manim.Scene`
-        The scene where the object should exist.
-    __arr : :class:`list`
-        Array to attach the pointer to.
-    __index : :class:`int`, default = `0`
-        Index of the array to attach the pointer to.
-    __label : :class:`str`, default: `''`
-        Specifies the label of the pointer.
-    __arrow_len : :class:`float`, default: `1`
-        Specifies the length of the arrow.
-    __arrow_gap : :class:`float`, default: `0.25`
-        Specifies the distance between the array and the arrow head.
-    __label_gap : :class:`float`, default: `0.25`
-        Specifies the distance betweem the label and the arrow tail.
-    __pointer_pos : :class:`.m_enum.MArrayDirection`, default: :attr:`.m_enum.MArrayDirection.DOWN`
-        Specifies the poistion of the pointer w.r.t the array.
-    __mob_arrow_props : :class:`dict`, default: `{}`
-        Arguments for :class:`manim.Arrow` that represents the arrow for :class:`MArrayPointer`.
-    __mob_label_props : :class:`dict`, default: `{}`
-        Arguments for :class:`manim.Text` that represents the label for :class:`MArrayPointer`.
-    __updater_pos : typing.Callable[[], None]
-        Updater function to keep the pointer intact with the array.
+    __scene : :class:`~manim.scene.scene.Scene`
+        The scene where the object is to be rendered.
+    __arr : :class:`~typing.List`\0[:class:`MArrayElement`]
+        The array to which the pointer is attached to.
+    __index : :class:`int`
+        The index of the element to which the pointer is attached to.
+    __label : :class:`str`
+        The value of the pointer label.
+    __arrow_len : :class:`float`
+        The length of :attr:`__mob_arrow`.
+    __arrow_gap : :class:`float`
+        The distance between :attr:`__mob_arrow` and :attr:`__arr`.
+    __label_gap : :class:`float`
+        The distance between :attr:`__mob_arrow` and :attr:`__mob_label`.
+    __pointer_pos : :class:`.m_enum.MArrayDirection`
+        The position of the pointer w.r.t to :attr:`__arr`.
+    __mob_arrow_props : :class:`dict`
+        Arguments for :class:`~manim.mobject.geometry.line.Arrow` that represents the pointer arrow.
+    __mob_label_props : :class:`dict`
+        Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the pointer label.
+    __mob_arrow : :class:`~manim.mobject.geometry.line.Arrow`
+        Represents the arrow of the element.
+    __mob_label : :class:`~manim.mobject.text.text_mobject.Text`
+        Represents the label of the element.
+    __updater_pos : :data:`typing.Callable`\0[[], None]
+        The updater function that keeps the pointer intact with the array.
     """
 
     __dir_map = [
@@ -1567,14 +1571,15 @@ class MArrayPointer(VGroup):
         {"np": RIGHT, "dir": MArrayDirection.RIGHT},
         {"np": LEFT, "dir": MArrayDirection.LEFT},
     ]
+    """Maps :class:`~.m_enum.MArrayDirection` to :class:`np.ndarray`."""
 
     def __calc_arrow_pos(self) -> np.ndarray:
-        """Calculates direction vector for :class:`manim.Arrow`.
+        """Calculates direction vector for the arrow mobject.
 
         Returns
         -------
         :class:`np.ndarray`
-            Position vector for the arrow.
+            Position vector for :attr:`__mob_arrow`.
         """
 
         arr_dir_np = self.__dir_map[self.__arr.fetch_arr_dir().value]["np"]
@@ -1592,7 +1597,7 @@ class MArrayPointer(VGroup):
         return arrow_pos_np
 
     def __add_updater(self) -> None:
-        """Attaches the position updater with the object."""
+        """Attaches the position updater function with the pointer."""
 
         def updater_pos(mob: Mobject) -> None:
             self.__init_pos()
@@ -1602,7 +1607,7 @@ class MArrayPointer(VGroup):
         self.add_updater(self.__updater_pos)
 
     def __remove_updater(self) -> None:
-        """Removes the attached updater from the object."""
+        """Removes the attached position updater function from the pointer."""
 
         self.remove_updater(self.__updater_pos)
 
@@ -1611,8 +1616,8 @@ class MArrayPointer(VGroup):
 
         Parameters
         ----------
-        :class:`int`
-            New index towards which the pointer should point to.
+        new_index
+            Specifies the prospective index of element to which the pointer is to be attached.
 
         Returns
         -------
@@ -1655,22 +1660,22 @@ class MArrayPointer(VGroup):
 
         Parameters
         ----------
-        scene : :class:`manim.Scene`
-            The scene where the object should exist.
-        arr : :class:`MArray`
-            Array to attach the pointer to.
-        index : :class:`int`
-            Index of the array to which the pointer is attached.
-        label : :class:`str`
-            Specifies the label of the pointer.
-        arrow_len : :class:`.enum.MArrayDirection`
-            Specifies the length of :class:`manim.Arrow`.
-        arrow_pos_gap : :class:`float`
-            Specifies the distance between :attr:`__mob_arr` and :attr:`__mob_arrow`.
-        label_gap : :class:`float`
+        scene
+            Specifies the scene where the object is to be rendered.
+        arr
+            Specifies the array to which the pointer is to be attached.
+        index
+            Specifies the index of the element to which the pointer is to be attached.
+        label
+            Specifies the value of the pointer label.
+        arrow_len
+            Specifies the length of :attr:`__mob_arrow`.
+        arrow_gap
+            Specifies the distance between :attr:`__mob_arrow` and :attr:`__arr`.
+        label_gap
             Specifies the distance between :attr:`__mob_arrow` and :attr:`__mob_label`.
-        pointer_pos : :class:`MArrayDirection`
-            Specifies the position of the pointer.
+        pointer_pos
+            Specifies the position of the pointer w.r.t to :attr:`__arr`.
         """
 
         self.__mob_arrow_props: dict = {"color": GOLD_D}
@@ -1686,15 +1691,17 @@ class MArrayPointer(VGroup):
         self.__label_gap: float = label_gap
         self.__pointer_pos: MArrayDirection = pointer_pos
 
-    def __update_props(self, mob_arrow_args: dict = {}, mob_label_args: dict = {}):
+    def __update_props(
+        self, mob_arrow_args: dict = {}, mob_label_args: dict = {}
+    ) -> None:
         """Updates the attributes of the class.
 
         Parameters
         ----------
-        mob_arrow_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Arrow` that represents the pointer arrow.
-        mob_label_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the pointer label.
+        mob_arrow_args
+            Arguments for :class:`~manim.mobject.geometry.line.Arrow` that represents the pointer arrow.
+        mob_label_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the pointer label.
         """
 
         self.__mob_arrow_props.update(mob_arrow_args)
@@ -1704,15 +1711,15 @@ class MArrayPointer(VGroup):
         if type(self.__mob_label_props["text"]) != str:
             self.__mob_label_props["text"] = str(self.__mob_label_props["text"])
 
-    def __init_mobs(self, init_arrow: bool = False, init_label: bool = False):
-        """Initializes the :class:`Mobject`s for the class.
+    def __init_mobs(self, init_arrow: bool = False, init_label: bool = False) -> None:
+        """Initializes the mobjects for the class.
 
         Parameters
         ----------
-        init_arrow : :class:`bool`, default: `False`
-            Instantiates a :class:`manim.Arrow` and adds it to :attr:`__mob_arrpw`.
-        init_label : :class:`bool`, default: `False`
-            Instantiates a :class:`manim.Text` and adds it to :attr:`__mob_label`.
+        init_arrow
+            If `True`, instantiates a :class:`~manim.mobject.geometry.line.Arrow` and assigns it to :attr:`__mob_arrow`.
+        init_label
+            If `True`, instantiates a :class:`~manim.mobject.text.text_mobject.Text` and assigns it to :attr:`__mob_label`.
         """
 
         if init_arrow:
@@ -1779,26 +1786,26 @@ class MArrayPointer(VGroup):
 
         Parameters
         ----------
-        scene : :class:`manim.Scene`
-            The scene where the object should exist.
-        arr : typing.List[:class:`MArray`]
-            Array to attach the pointer to.
-        index : :class:`int`, default = `0`
-            Index of the array to attach the pointer to.
-        label : :class:`str`, default: `''`
-            Specifies the label of the pointer.
-        arrow_len : :class:`float`, default: `1`
-            Specifies the length of the arrow.
-        arrow_gap : :class:`float`, default: `0.25`
-            Specifies the distance between the array and the arrow head.
-        label_gap : :class:`float`, default: `0.25`
-            Specifies the distance betweem the label and the arrow tail.
-        pointer_pos : :class:`.m_enum.MArrayDirection`, default: :attr:`.m_enum.MArrayDirection.DOWN`
-            Specifies the poistion of the pointer w.r.t the array.
-        mob_arrow_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Arrow` that represents the arrow for :class:`MArrayPointer`.
-        mob_label_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the label for :class:`MArrayPointer`.
+        scene
+            Specifies the scene where the object is to be rendered.
+        arr
+            Specifies the array to which the pointer is to be attached.
+        index
+            Specifies the index of the element to which the pointer is to be attached.
+        label
+            Specifies the value of the pointer label.
+        arrow_len
+            Specifies the length of :attr:`__mob_arrow`.
+        arrow_gap
+            Specifies the distance between :attr:`__mob_arrow` and :attr:`__arr`.
+        label_gap
+            Specifies the distance between :attr:`__mob_arrow` and :attr:`__mob_label`.
+        pointer_pos
+            Specifies the position of the pointer w.r.t to :attr:`__arr`.
+        mob_arrow_args
+            Arguments for :class:`~manim.mobject.geometry.line.Arrow` that represents the pointer arrow.
+        mob_label_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the pointer label.
         **kwargs
             Forwarded to constructor of the parent.
         """
@@ -1819,72 +1826,24 @@ class MArrayPointer(VGroup):
         # Add updater
         self.__add_updater()
 
-    def shift_to_elem(
-        self, index: int, play_anim: bool = True, play_anim_args: dict = {}
-    ) -> ApplyMethod:
-        """Shifts pointer to the specified element.
-
-        Parameters
-        ----------
-        index : :class:`int`
-            Index of the array to shift the pointer to.
-        play_anim : :class:`bool`, default: `True`
-            Specifies whether to play the :class:`manim.Animation`.
-        play_anim_args : :class:`dict, default: `{}`
-            Arguments for :meth:`manim.Scene.play`.
-
-        Returns
-        -------
-        :class:`manim.ApplyMethod`
-            Represents the shifting animation.
-        """
-
-        if index < 0 or index > len(self.__arr.fetch_mob_arr()):
-            raise Exception("Index out of bounds!")
-
-        shift_anim = ApplyMethod(
-            self.shift, self.__calc_shift_np(index), suspend_mobject_updating=True
-        )
-        self.__index = index
-
-        if play_anim:
-            self.__scene.play(shift_anim, **play_anim_args)
-
-        return shift_anim
-
-    def attach_to_elem(self, index: int) -> None:
-        """Attaches pointer to the specified element.
-
-        Parameters
-        ----------
-        index : :class:`int`
-            Index of the array to shift the pointer to.
-        """
-
-        if index < 0 or index > len(self.__arr.fetch_mob_arr()):
-            raise Exception("Index out of bounds!")
-
-        self.__index = index
-        self.__init_pos()
-
     def fetch_mob_arrow(self) -> Arrow:
-        """Fetches :attr:`__mob_arrow`.
+        """Fetches the arrow mobject of the pointer.
 
         Returns
         -------
-        :class:`manim.Arrow`
-            Represents the arrow stored in :attr:`__mob_arrow`.
+        :class:`~manim.mobject.geometry.line.Arrow`
+            :attr:`__mob_arrow`.
         """
 
         return self.__mob_arrow
 
     def fetch_mob_label(self) -> Text:
-        """Fetches the :class:`manim.Text` that represents the pointer label.
+        """Fetches the label mobject of the pointer.
 
         Returns
         -------
-        :class:`manim.Text`
-            Represents the pointer label.
+        :class:`~manim.mobject.text.text_mobject.Text`
+            :attr:`__mob_label`.
         """
 
         return self.__mob_label
@@ -1895,7 +1854,7 @@ class MArrayPointer(VGroup):
         Returns
         -------
         :class:`int`
-            Represents the index that the pointer is attached to.
+            :attr:`__index`.
         """
 
         return self.__index
@@ -1909,25 +1868,27 @@ class MArrayPointer(VGroup):
         play_anim: bool = True,
         play_anim_args: dict = {},
     ) -> Text:
-        """Re-intializes the :class:`manim.Text` that represents the pointer label.
+        """Updates the pointer label.
 
         Parameters
         ----------
-        mob_label_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the pointer label.
-        update_anim : :class:`manim.Animation`, default `manim.Write`
-            Animation to be applied to the updated :class:`manim.Text`.
-        update_anim_args : :class:`dict`, default: `{}`
-            Arguments for update :class:`manim.Animation`.
-        play_anim : :class:`bool`, default: `True`
-            Specifies whether to play the update :class:`manim.Animation`.
-        play_anim_args : :class:`dict, default: `{}`
-            Arguments for :meth:`manim.Scene.play`.
+        label
+            New value to be assigned to the pointer label.
+        mob_label_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the pointer label.
+        update_anim
+            Animation to be applied to the updated pointer label.
+        update_anim_args
+            Arguments for update :class:`~manim.animation.animation.Animation`.
+        play_anim
+            If `True`, plays the animation(s).
+        play_anim_args
+            Arguments for :py:meth:`Scene.play() <manim.scene.scene.Scene.play>`.
 
         Returns
         -------
-        :class:`manim.Text`
-            Represents the updated pointer label.
+        :class:`~manim.mobject.text.text_mobject.Text`
+            Updated :attr:`__mob_label`.
         """
 
         self.__label = label
@@ -1953,23 +1914,71 @@ class MArrayPointer(VGroup):
         return self.__mob_label
 
     def animate_mob_arrow(self) -> "_AnimationBuilder":  # type: ignore
-        """Invokes the :meth:`manim.Arrow.animate` property of :class:`manim.Arrow` for the pointer arrow.
+        """Invokes the animate property over arrow mobject.
 
         Returns
         -------
         :class:`_AnimationBuilder`
-            Value returned by :meth:`manim.Arrow.animate` property of :class:`manim.Arrow`.
+            Animate property of :attr:`__mob_arrow`.
         """
 
         return self.__mob_arrow.animate
 
     def animate_mob_label(self) -> "_AnimationBuilder":  # type: ignore
-        """Invokes the :meth:`manim.Text.animate` property of :class:`manim.Text` for the pointer label.
+        """Invokes the animate property over label mobject.
 
         Returns
         -------
         :class:`_AnimationBuilder`
-            Value returned by :meth:`manim.Text.animate` property of :class:`manim.Text`.
+            Animate property of :attr:`__mob_label`.
         """
 
         return self.__mob_label.animate
+
+    def shift_to_elem(
+        self, index: int, play_anim: bool = True, play_anim_args: dict = {}
+    ) -> ApplyMethod:
+        """Shifts pointer to the specified element.
+
+        Parameters
+        ----------
+        index
+            Specifies the index of the element to which the pointer is to be shifted.
+        play_anim
+            If `True`, plays the animation(s).
+        play_anim_args
+            Arguments for :py:meth:`Scene.play() <manim.scene.scene.Scene.play>`.
+
+        Returns
+        -------
+        :class:`~manim.animation.transform.ApplyMethod`
+            Shift animation.
+        """
+
+        if index < 0 or index > len(self.__arr.fetch_mob_arr()):
+            raise Exception("Index out of bounds!")
+
+        shift_anim = ApplyMethod(
+            self.shift, self.__calc_shift_np(index), suspend_mobject_updating=True
+        )
+        self.__index = index
+
+        if play_anim:
+            self.__scene.play(shift_anim, **play_anim_args)
+
+        return shift_anim
+
+    def attach_to_elem(self, index: int) -> None:
+        """Attaches pointer to the specified element.
+
+        Parameters
+        ----------
+        index
+            Specifies the index of the element to which the pointer is to be attached.
+        """
+
+        if index < 0 or index > len(self.__arr.fetch_mob_arr()):
+            raise Exception("Index out of bounds!")
+
+        self.__index = index
+        self.__init_pos()

--- a/src/manim_data_structures/m_array.py
+++ b/src/manim_data_structures/m_array.py
@@ -32,34 +32,30 @@ class MArrayElement(VGroup):
     label_gap
         Specifies the distance between :attr:`__mob_label` and :attr:`__mob_square`.
     next_to_mob
-        Specifies placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
+        Specifies the placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
     next_to_dir
-        Specifies direction of placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
+        Specifies the direction of placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
 
     Attributes
     ----------
     __scene : :class:`~manim.scene.scene.Scene`
-        Specifies the scene where the object is to be rendered.
-    __mob_square_args : :class:`dict`
+        The scene where the object is to be rendered.
+    __mob_square_props : :class:`dict`
         Arguments for :class:`~manim.mobject.geometry.polygram.Square` that represents the element body.
-    __mob_value_args : :class:`dict`
+    __mob_value_props : :class:`dict`
         Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element value.
-    __mob_index_args : :class:`dict`
+    __mob_index_props : :class:`dict`
         Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element index.
-    __mob_label_args : :class:`dict`
+    __mob_label_props : :class:`dict`
         Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element label.
     __index_pos : :class:`np.ndarray`
-        Specifies the position of :attr:`__mob_index` w.r.t :attr:`__mob_square`
+        The position of :attr:`__mob_index` w.r.t :attr:`__mob_square`
     __index_gap : :class:`float`
-        Specifies the distance between :attr:`__mob_index` and :attr:`__mob_square`.
+        The distance between :attr:`__mob_index` and :attr:`__mob_square`.
     __label_pos : :class:`np.ndarray`
-        Specifies the position of :attr:`__mob_label` w.r.t :attr:`__mob_square`.
+        The position of :attr:`__mob_label` w.r.t :attr:`__mob_square`.
     __label_gap : :class:`float`
-        Specifies the distance between :attr:`__mob_label` and :attr:`__mob_square`.
-    __next_to_mob : :class:`MArrayElement`
-        Specifies placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
-    __next_to_dir : :class:`float`
-        Specifies direction of placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
+        The distance between :attr:`__mob_label` and :attr:`__mob_square`.
     __mob_square : :class:`~manim.mobject.geometry.polygram.Square`
         Represents the body of the element.
     __mob_value : :class:`~manim.mobject.text.text_mobject.Text`
@@ -249,9 +245,9 @@ class MArrayElement(VGroup):
         label_gap
             Specifies the distance between :attr:`__mob_label` and :attr:`__mob_square`.
         next_to_mob
-            Specifies placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
+            Specifies the placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
         next_to_dir
-            Specifies direction of placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
+            Specifies the direction of placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
         """
 
         super().__init__(**kwargs)
@@ -533,63 +529,65 @@ class MArray(VGroup):
 
     Parameters
     ----------
-    scene : :class:`manim.Scene`
-        The scene where the object should exist.
-    arr : :class:`list`, default: `[]`
-        Array to represent. Elements must be convertible to :class:`str`.
-    label : :class:`str`, default: `''`
-        Specifies the label of the array.
-    index_offset : :class:`int`, default: `1`
-        Difference between successive indices.
-    index_start : :class:`int`, default: `0`
-        Starting value of index.
-    index_hex_display : :class:`bool`, default: `False`
-        Displays indices in hex if `True` otherwise in decimal.
-    hide_index : :class:`bool`, default: `False`
-        Specifies whether to display indices or not.
-    arr_dir : :class:`.m_enum.MArrayDirection`, default: :attr:`.m_enum.MArrayDirection.RIGHT`
-        Specifies the growing direction of array.
-    arr_label_pos : :class:`.enum.MArrayDirection`, default: :attr:`.m_enum.MArrayDirection.LEFT`
-        Specifies the position of :attr:`__mob_arr_label`.
-    arr_label_gap : :class:`float`, default: `0.5`
-        Specifies the distance between :attr:`__mob_arr` and :attr:`__mob_arr_label`.
-    mob_arr_label_args : :class:`dict`, default: `{}`
-        Arguments for :class:`manim.Text` that represents the label for :class:`MArray`.
-    mob_square_args : :class:`dict`, default: `{}`
-        Arguments for :class:`manim.Square` that represents the element body of :class:`MArrayElement`.
-    mob_value_args : :class:`dict`, default: `{}`
-        Arguments for :class:`manim.Text` that represents the element value of :class:`MArrayElement`.
-    mob_index_args : :class:`dict`, default: `{}`
-        Arguments for :class:`manim.Text` that represents the element index of :class:`MArrayElement`.
+    scene
+        Specifies the scene where the object is to be rendered.
+    arr
+        Specifies the array to represent.
+    label
+        Specifies the value of the array label.
+    index_offset
+        Specifies the difference between successive displayable indices.
+    index_start
+        Specifies the starting value of displayable index.
+    index_hex_display
+        If `True`, displays indices in hex.
+    hide_index
+        If `True`, doesn't display indices.
+    arr_dir
+        Specifies the growth direction of the array.
+    arr_label_pos
+        Specifies the position of :attr:`__mob_arr_label` w.r.t :attr:`__mob_arr`.
+    arr_label_gap
+        Specifies the distance between :attr:`__mob_arr_label` and :attr:`__mob_arr`.
+    mob_arr_label_args
+        Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the array label.
+    mob_square_args
+        Arguments for :class:`~manim.mobject.geometry.polygram.Square` that represents the element body.
+    mob_value_args
+        Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element value.
+    mob_index_args
+        Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element index.
     **kwargs
         Forwarded to constructor of the parent.
 
     Attributes
     ----------
-    __scene : :class:`manim.Scene`
-        The scene where the object should exist.
+    __scene : :class:`~manim.scene.scene.Scene`
+        The scene where the object is to be rendered.
     __arr : :class:`list`
-        Array to represent. Elements must be convertible to :class:`str`.
-    __mob_arr : List[:class:`MArrayElement`]
-        Array containing the manim objects.
+        The array to represent.
     __label : :class:`str`
-        Specifies the label of the array.
+        The value of the array label.
     __index_offset : :class:`int`
-        Difference between successive indices.
+        The difference between successive displayable indices.
     __index_start : :class:`int`
-        Starting value of index.
+        The starting value of displayable index.
     __index_hex_display : :class:`bool`
-        Displays indices in hex if `True` otherwise in decimal.
+        If `True`, displays indices in hex.
     __hide_index : :class:`bool`
-        Specifies whether to display indices or not.
-    __arr_dir : :class:`.m_enum.MArrayDirection`
-        Specifies the growing direction of array.
-    __arr_label_pos : :class:`.enum.MArrayDirection`
-        Specifies the position of :attr:`__mob_arr_label`.
-    __arr_label_gap : :class:`float`, default: `0.5`
-        Specifies the distance between :attr:`__mob_arr` and :attr:`__mob_arr_label`.
+        If `True`, doesn't display indices.
+    __arr_dir : :class:`~.m_enum.MArrayDirection`
+        The growth direction of the array.
+    __arr_label_pos : :class:`~.m_enum.MArrayDirection`
+        The position of :attr:`__mob_arr_label` w.r.t :attr:`__mob_arr`.
+    __arr_label_gap : :class:`float`
+        The distance between :attr:`__mob_arr_label` and :attr:`__mob_arr`.
     __mob_arr_label_props : :class:`dict`
-        Arguments for :class:`manim.Text` that represents the label for :class:`MArray`.
+        Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the array label.
+    __mob_arr : :class:`~typing.List`\0[:class:`MArrayElement`]
+        Represents the array.
+    __mob_arr_label : :class:`~manim.mobject.text.text_mobject.Text`
+        Represents the array label.
     """
 
     __dir_map = [
@@ -598,22 +596,22 @@ class MArray(VGroup):
         {"arr": RIGHT, "index": UP},
         {"arr": LEFT, "index": UP},
     ]
-    """Maps :class:`.m_enum.MArrayDirection` to correct :class:`MArrayElement` placement."""
+    """Maps :class:`~.m_enum.MArrayDirection` to :class:`np.ndarray`."""
 
     def __sum_elem_len(self, index_start: int, index_end: int) -> int:
-        """Sums the length of :class:`manim.Square` elements between the specified bound.
+        """Sums the side_length of all elements' square mobject present in the array between the specified range.
 
         Parameters
         ----------
-        index_start : :class:`int`
-            Starting index of the bound (inclusive).
-        index_end : :class:`int`
-            Ending index of the bound (inclusive).
+        index_start
+            Starting index of the range (inclusive).
+        index_end
+            Ending index of the range (inclusive).
 
         Returns
         -------
         :class:`int`
-            Total length of the elements.
+            Sum of `side_length`\0s of all :class:`~manim.mobject.geometry.polygram.Square` present inside :attr:`__mob_arr` in the specified range.
         """
 
         if (
@@ -630,14 +628,14 @@ class MArray(VGroup):
         return total_len
 
     def __calc_label_pos_and_mob(self) -> typing.Tuple[Square, np.ndarray]:
-        """Calculates the position of the label relative to :class:`MArrayElement` 's :class:`manim.Square` and returns them.
+        """Calculates the position of the array label relative to one of the element's square mobjects.
 
         Returns
         -------
-        :class:`Manim.Square`
-            Represents the :class:`manim.Mobject` next to which the label is positioned.
+        :class:`~manim.mobject.geometry.polygram.Square`
+            Square mobject next to which the array label is positioned.
         :class:`np.ndarray`
-            Represents the relative label's position.
+            The relative position of the array label.
         """
 
         # Label position is parallel to array growth direction
@@ -677,16 +675,16 @@ class MArray(VGroup):
             )
 
     def __calc_index(self, index: int) -> typing.Union[int, str]:
-        """Calculates and returns the index based on attributes set at initialization.
+        """Calculates the displayable index of the specified element based on attributes set at initialization.
 
         Parameters
         ----------
-        index : :class:`int`
-            Index of the :attr:`__arr` for which to compute the displayable index.
+        index
+            Specifies the index of the element for which to compute the displayable index.
 
         Returns
         -------
-        Union[:class:`int`, :class:`str`]
+        :data:`~typing.Union`\0[:class:`int`, :class:`str`]
             Displayable index.
         """
 
@@ -701,12 +699,12 @@ class MArray(VGroup):
         )
 
     def __calc_index_pos(self) -> np.ndarray:
-        """Calculates and returns the index position based on attributes set at initialization.
+        """Calculates the index position of all elements based on attributes set at initialization.
 
         Returns
         -------
         :class:`np.ndarray`
-            Represents the index position.
+            Index position.
         """
 
         return (
@@ -716,16 +714,16 @@ class MArray(VGroup):
         )
 
     def __calc_label_shift_factor(self, mob: MArrayElement) -> float:
-        """Calculates how much to shift the :attr:`__mob_arr_label` after insertion/removal of an :class:`MArrayElement`.
+        """Calculates how much to shift the array label after insertion/removal of an element.
 
         Parameters
         ----------
-        mob : :class:`MArrayElement`
-            The element that has been inserted or removed.
+        mob
+            Specifies the element that is inserted/removed.
 
         Returns
         -------
-        :class:`int`
+        :class:`float`
             Factor by which to shift the :attr:`__mob_arr_label`.
         """
 
@@ -752,31 +750,31 @@ class MArray(VGroup):
         mob_value_args: dict = {},
         mob_index_args: dict = {},
     ) -> typing.List[Animation]:
-        """Creates a new :class:`MArrayElement` and appends it to :attr:`__mob_arr`.
+        """Creates and inserts a new element in the array.
 
         Parameters
         ----------
         value
-            Value to append.
-        shift_label: :class:`bool`, default: `True`
-            Specifies whether to shift the :class:`__mob_arr_label` or not.
-        append_anim : :class:`manim.Animation`, default: :class:`manim.Write`
-            Specifies the :class:`manim.Animation` to be played on the :class:`MArrayElement` being appended.
-        append_anim_args : :class:`dict`, default: `{}`
-            Arguments for append :class:`manim.Animation`.
-        append_anim_target : :class:`.m_enum.MArrayElementComp`, default: `None`
-            Specifies the :class:`manim.Mobject` of the :class:`MArrayElement` on which the append :class:`manim.Animation` is to be played.
-        mob_square_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Square` that represents the element body of :class:`MArrayElement`.
-        mob_value_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element value of :class:`MArrayElement`.
-        mob_index_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element index of :class:`MArrayElement`.
+            Specifies the value of the new element.
+        shift_label
+            If `True`, shifts the :attr:`__mob_arr_label` to center of the array.
+        append_anim
+            Animation to be applied to the new element.
+        append_anim_args
+            Arguments for append :class:`~manim.animation.animation.Animation`.
+        append_anim_target
+            Specifies the target :class:`~manim.mobject.mobject.Mobject` of the :class:`MArrayElement` on which the append :class:`~manim.animation.animation.Animation` is to be played.
+        mob_square_args
+            Arguments for :class:`~manim.mobject.geometry.polygram.Square` that represents the element body.
+        mob_value_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element value.
+        mob_index_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element index.
 
         Returns
         -------
-        List[:class:`manim.Animation`]
-            List of animations for appending.
+        :data:`typing.List`\0[:class:`~manim.animation.animation.Animation`]
+            List of append animations.
         """
 
         mob_value_args["text"] = value
@@ -821,31 +819,31 @@ class MArray(VGroup):
         removal_anim_target: MArrayElementComp = None,
         update_anim_target: MArrayElementComp = MArrayElementComp.INDEX,
     ) -> typing.Tuple[Succession, typing.Callable[[bool], typing.List[Animation]]]:
-        """Removes the :class:`MArrayElement` from :attr:`__mob_arr` at the specified index.
+        """Removes the element from the array at the specified index.
 
         Parameters
         ----------
-        index : :class:`int`
-            Index of :class:`MArrayElement` to remove.
-        removal_anim : :class:`manim.Animation`, default: :class:`manim.FadeOut`
-            Specifies the :class:`manim.Animation` to be played on the :class:`MArrayElement` being removed.
-        update_anim : :class:`manim.Animation`, default: :class:`manim.Write`
-            Specifies the :class:`manim.Animation` to be played on the :class:`MArrayElement`(s) after the removed element.
-        removal_anim_args : :class:`dict`, default: `{}`
-            Arguments for removal :class:`manim.Animation`.
-        update_anim_args : :class:`dict`, default: `{}`
-            Arguments for update :class:`manim.Animation`.
-        removal_anim_target : :class:`.m_enum.MArrayElementComp`, default: `None`
-            Specifies the :class:`manim.Mobject` of the :class:`MArrayElement` on which the removal :class:`manim.Animation` is to be played.
-        update_anim_target : :class:`.m_enum.MArrayElementComp`, default: :attr:`.m_enum.MArrayElementComp.INDEX`
-            Specifies the :class:`manim.Mobject` of the :class:`MArrayElement` on which the update :class:`manim.Animation` is to be played.
+        index
+            Specifies the index of the element to remove.
+        removal_anim
+            Animation to be applied to the element being removed.
+        update_anim
+            Animation to be applied on remaining elements.
+        removal_anim_args
+            Arguments for removal :class:`~manim.animation.animation.Animation`.
+        update_anim_args
+            Arguments for update :class:`~manim.animation.animation.Animation`.
+        removal_anim_target
+            Specifies the target :class:`~manim.mobject.mobject.Mobject` of the :class:`MArrayElement` on which the removal :class:`~manim.animation.animation.Animation` is to be played.
+        update_anim_target
+            Specifies the target :class:`~manim.mobject.mobject.Mobject` of the :class:`MArrayElement` on which the update :class:`~manim.animation.animation.Animation` is to be played.
 
         Returns
         -------
-        :class:`manim.Succession`
-            Contains :class:`manim.Animations` played for removal and shifting of :class:`MArrayElement`.
-        Callable[[bool], List[:class:`manim.Animation`]]
-            Method that updates the indices of :class:`MArrayElement`(s) that occur after the removal and returns a list of update :class:`manim.Animation`(s).
+        :class:`~manim.animation.composition.Succession`
+            Contains :class:`~manim.animation.animation.Animation` played for removal and shifting of element(s).
+        :data:`~typing.Callable`\0[[:class:`bool`], :class:`~typing.List`\0[:class:`~manim.animation.animation.Animation`]]
+            Method that updates the indices of element(s) after the removed element and returns a list of update :class:`~manim.animation.animation.Animation`\0(s).
         """
 
         if index < 0 or index > len(self.__mob_arr):
@@ -940,26 +938,26 @@ class MArray(VGroup):
 
         Parameters
         ----------
-        scene : :class:`manim.Scene`
-            The scene where the object should exist.
-        arr : :class:`list`
-            Array to represent. Elements must be convertible to :class:`str`.
-        label : :class:`str`
+        scene
+            Specifies the scene where the object is to be rendered.
+        arr
+            Specifies the array to represent.
+        label
             Specifies the label of the array.
-        index_offset : :class:`int`
-            Difference between successive indices.
-        index_start : :class:`int`
-            Starting value of index.
-        index_hex_display : :class:`bool`
-            Displays indices in hex if `True` otherwise in decimal.
-        hide_index : :class:`bool`
-            Specifies whether to display indices or not.
-        arr_dir : :class:`.m_enum.MArrayDirection`
-            Specifies the growing direction of array.
-        arr_label_pos : :class:`.enum.MArrayDirection`
-            Specifies the position of :attr:`__mob_arr_label`.
-        arr_label_gap : :class:`float`
-            Specifies the distance between :attr:`__mob_arr` and :attr:`__mob_arr_label`.
+        index_offset
+            Specifies the difference between successive displayable indices.
+        index_start
+            Specifies the starting value of displayable index.
+        index_hex_display
+            If `True`, displays indices in hex.
+        hide_index
+            If `True`, doesn't display indices.
+        arr_dir
+            Specifies the growth direction of the array.
+        arr_label_pos
+            Specifies the position of :attr:`__mob_arr_label` w.r.t :attr:`__mob_arr`.
+        arr_label_gap
+            Specifies the distance between :attr:`__mob_arr_label` and :attr:`__mob_arr`.
         """
 
         self.__mob_arr_label_props: dict = {
@@ -988,8 +986,8 @@ class MArray(VGroup):
 
         Parameters
         ----------
-        mob_arr_label_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the array label.
+        mob_arr_label_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the array label.
         """
 
         self.__mob_arr_label_props["text"] = self.__label
@@ -1002,12 +1000,12 @@ class MArray(VGroup):
         self,
         init_arr_label: bool = False,
     ) -> None:
-        """Initializes the :class:`Mobject`s for the class.
+        """Initializes the mobjects for the class.
 
         Parameters
         ----------
-        init_arr_label : :class:`bool`, default: `False`
-            Instantiates a :class:`manim.Text` and adds it to :attr:`__mob_arr_label`.
+        init_arr_label
+            If `True`, instantiates a :class:`~manim.mobject.text.text_mobject.Text` and assigns it to :attr:`__mob_arr_label`.
         """
 
         if init_arr_label:
@@ -1060,34 +1058,34 @@ class MArray(VGroup):
 
         Parameters
         ----------
-        scene : :class:`manim.Scene`
-            The scene where the object should exist.
-        arr : :class:`list`, default: `[]`
-            Array to represent. Elements must be convertible to :class:`str`.
-        label : :class:`str`, default: `''`
+        scene
+            Specifies the scene where the object is to be rendered.
+        arr
+            Specifies the array to represent.
+        label
             Specifies the label of the array.
-        index_offset : :class:`int`, default: `1`
-            Difference between successive indices.
-        index_start : :class:`int`, default: `0`
-            Starting value of index.
-        index_hex_display : :class:`bool`, default: `False`
-            Displays indices in hex if `True` otherwise in decimal.
-        hide_index : :class:`bool`, default: `False`
-            Specifies whether to display indices or not.
-        arr_dir : :class:`.m_enum.MArrayDirection`, default: :attr:`.m_enum.MArrayDirection.RIGHT`
-            Specifies the growing direction of array.
-        arr_label_pos : :class:`.enum.MArrayDirection`, default: :attr:`.m_enum.MArrayDirection.LEFT`
-            Specifies the position of :attr:`__mob_arr_label`.
-        arr_label_gap : :class:`float`, default: `0.5`
-            Specifies the distance between :attr:`__mob_arr` and :attr:`__mob_arr_label`.
-        mob_arr_label_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the label for :class:`MArray`.
-        mob_square_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Square` that represents the element body of :class:`MArrayElement`.
-        mob_value_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element value of :class:`MArrayElement`.
-        mob_index_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element index of :class:`MArrayElement`.
+        index_offset
+            Specifies the difference between successive displayable indices.
+        index_start
+            Specifies the starting value of displayable index.
+        index_hex_display
+            If `True`, displays indices in hex.
+        hide_index
+            If `True`, doesn't display indices.
+        arr_dir
+            Specifies the growth direction of the array.
+        arr_label_pos
+            Specifies the position of :attr:`__mob_arr_label` w.r.t :attr:`__mob_arr`.
+        arr_label_gap
+            Specifies the distance between :attr:`__mob_arr_label` and :attr:`__mob_arr`.
+        mob_arr_label_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the array label.
+        mob_square_args
+            Arguments for :class:`~manim.mobject.geometry.polygram.Square` that represents the element body.
+        mob_value_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element value.
+        mob_index_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element index.
         **kwargs
             Forwarded to constructor of the parent.
         """
@@ -1125,6 +1123,50 @@ class MArray(VGroup):
         # Initialize other mobjects (e.g. __arr_label)
         self.__init_mobs(True)
 
+    def fetch_arr(self) -> list:
+        """Fetches the original array.
+
+        Returns
+        -------
+        :class:`list`
+            :attr:`__arr`.
+        """
+
+        return self.__arr
+
+    def fetch_mob_arr(self) -> typing.List[MArrayElement]:
+        """Fetches the mobject array.
+
+        Returns
+        -------
+        :class:`~typing.List`
+            :attr:`__mob_arr`.
+        """
+
+        return self.__mob_arr
+
+    def fetch_mob_arr_label(self) -> Text:
+        """Fetches the label mobject of the array.
+
+        Returns
+        -------
+        :class:`~manim.mobject.text.text_mobject.Text`
+            :attr:`__mob_arr_label`.
+        """
+
+        return self.__mob_arr_label
+
+    def fetch_arr_dir(self) -> MArrayDirection:
+        """Fetches the growth direction enum of the array.
+
+        Returns
+        -------
+        :class:`~.m_enum.MArrayDirection`
+            :attr:`__arr_dir`.
+        """
+
+        return self.__arr_dir
+
     def update_elem_value(
         self,
         index: int,
@@ -1139,25 +1181,25 @@ class MArray(VGroup):
 
         Parameters
         ----------
-        index : :class:`int`
-            Index of :attr:`__mob_arr` to update.
+        index
+            Specifies the index of element whose value to update.
         value
-            New value to be assigned.
-        mob_value_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element value of :class:`MArrayElement`.
-        update_anim : :class:`manim.Animation`, default `manim.Write`
-            Animation to be applied to the updated :class:`manim.Text`.
-        update_anim_args : :class:`dict`, default: `{}`
-            Arguments for update :class:`manim.Animation`.
-        play_anim : :class:`bool`, default: `True`
-            Specifies whether to play the update :class:`manim.Animation`.
-        play_anim_args : :class:`dict, default: `{}`
-            Arguments for :meth:`manim.Scene.play`.
+            New value to be assigned to the element.
+        mob_value_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element value.
+        update_anim
+            Animation to be applied to the updated element.
+        update_anim_args
+            Arguments for update :class:`~manim.animation.animation.Animation`.
+        play_anim
+            If `True`, plays the animation(s).
+        play_anim_args
+            Arguments for :py:meth:`Scene.play() <manim.scene.scene.Scene.play>`.
 
         Returns
         -------
-        :class:`manim.Text`
-            Represents the updated element value.
+        :class:`~manim.mobject.text.text_mobject.Text`
+            Updated element's value mobject.
         """
 
         if index < 0 or index > len(self.__mob_arr):
@@ -1183,25 +1225,25 @@ class MArray(VGroup):
 
         Parameters
         ----------
-        index : :class:`int`
-            Index of :attr:`__mob_arr` to update.
+        index
+            Specifies the index of element whose index to update.
         value
-            New value to be assigned.
-        mob_index_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element index of :class:`MArrayElement`.
-        update_anim : :class:`manim.Animation`, default `manim.Write`
-            Animation to be applied to the updated :class:`manim.Text`.
-        update_anim_args : :class:`dict`, default: `{}`
-            Arguments for update :class:`manim.Animation`.
-        play_anim : :class:`bool`, default: `True`
-            Specifies whether to play the update :class:`manim.Animation`.
-        play_anim_args : :class:`dict, default: `{}`
-            Arguments for :meth:`manim.Scene.play`.
+            New value to be assigned to the index of the element.
+        mob_index_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element index.
+        update_anim
+            Animation to be applied to the updated element.
+        update_anim_args
+            Arguments for update :class:`~manim.animation.animation.Animation`.
+        play_anim
+            If `True`, plays the animation(s).
+        play_anim_args
+            Arguments for :py:meth:`Scene.play() <manim.scene.scene.Scene.play>`.
 
         Returns
         -------
-        :class:`manim.Text`
-            Represents the updated element index.
+        :class:`~manim.mobject.text.text_mobject.Text`
+            Updated element's index mobject.
         """
 
         if index < 0 or index > len(self.__mob_arr):
@@ -1221,25 +1263,27 @@ class MArray(VGroup):
         play_anim: bool = True,
         play_anim_args: dict = {},
     ) -> Text:
-        """Re-intializes the :class:`manim.Text` that represents the array label.
+        """Updates the array label.
 
         Parameters
         ----------
-        mob_label_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the array label.
-        update_anim : :class:`manim.Animation`, default `manim.Write`
-            Animation to be applied to the updated :class:`manim.Text`.
-        update_anim_args : :class:`dict`, default: `{}`
-            Arguments for update :class:`manim.Animation`.
-        play_anim : :class:`bool`, default: `True`
-            Specifies whether to play the update :class:`manim.Animation`.
-        play_anim_args : :class:`dict, default: `{}`
-            Arguments for :meth:`manim.Scene.play`.
+        label
+            New value to be assigned to the array label.
+        mob_label_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the array label.
+        update_anim
+            Animation to be applied to the updated array label.
+        update_anim_args
+            Arguments for update :class:`~manim.animation.animation.Animation`.
+        play_anim
+            If `True`, plays the animation(s).
+        play_anim_args
+            Arguments for :py:meth:`Scene.play() <manim.scene.scene.Scene.play>`.
 
         Returns
         -------
-        :class:`manim.Text`
-            Represents the updated array label.
+        :class:`~manim.mobject.text.text_mobject.Text`
+            Updated :attr:`__mob_arr_label`.
         """
 
         self.__label = label
@@ -1265,17 +1309,17 @@ class MArray(VGroup):
         return self.__mob_arr_label
 
     def animate_elem(self, index: int) -> "_AnimationBuilder":  # type: ignore
-        """Invokes the :meth:`MArrayElement.animate` property of :class:`MArrayElement` on specified index of :attr:`__mob_arr`.
+        """Invokes the animate property over element mobject specified.
 
         Parameters
         ----------
-        index : :class:`int`
-            Index of :attr:`__mob_arr` to animate.
+        index
+            Specifies the index of the element to animate.
 
         Returns
         -------
         :class:`_AnimationBuilder`
-            Value returned by :meth:`MArrayElement.animate` property of :class:`MArrayElement`.
+            Animate property of :class:`MArrayElement`.
         """
 
         if index < 0 or index > len(self.__mob_arr):
@@ -1284,17 +1328,17 @@ class MArray(VGroup):
         return self.__mob_arr[index].animate
 
     def animate_elem_square(self, index: int) -> "_AnimationBuilder":  # type: ignore
-        """Invokes the :meth:`manim.Square.animate` property of :class:`manim.Square` on specified index of :attr:`__mob_arr`.
+        """Invokes the animate property over square mobject of the specified element.
 
         Parameters
         ----------
-        index : :class:`int`
-            Index of :attr:`__mob_arr` to animate.
+        index
+            Specifies the index of the element who's square mobject to animate.
 
         Returns
         -------
         :class:`_AnimationBuilder`
-            Value returned by :meth:`manim.Square.animate` property of :class:`manim.Square`.
+            Animate property of :class:`~manim.mobject.geometry.polygram.Square`.
         """
 
         if index < 0 or index > len(self.__mob_arr):
@@ -1303,17 +1347,17 @@ class MArray(VGroup):
         return self.__mob_arr[index].animate_mob_square()
 
     def animate_elem_value(self, index: int) -> "_AnimationBuilder":  # type: ignore
-        """Invokes the :meth:`manim.Text.animate` property of :class:`manim.Text` on specified index of :attr:`__mob_arr`.
+        """Invokes the animate property over value mobject of the specified element.
 
         Parameters
         ----------
-        index : :class:`int`
-            Index of :attr:`__mob_arr` to animate.
+        index
+            Specifies the index of the element who's value mobject animate.
 
         Returns
         -------
         :class:`_AnimationBuilder`
-            Value returned by :meth:`manim.Text.animate` property of :class:`manim.Text`.
+            Animate property of :class:`~manim.mobject.text.text_mobject.Text`.
         """
 
         if index < 0 or index > len(self.__mob_arr):
@@ -1322,17 +1366,17 @@ class MArray(VGroup):
         return self.__mob_arr[index].animate_mob_value()
 
     def animate_elem_index(self, index: int) -> "_AnimationBuilder":  # type: ignore
-        """Invokes the :meth:`manim.Text.animate` property of :class:`manim.Text` on specified index of :attr:`__mob_arr`.
+        """Invokes the animate property over index mobject of the specified element.
 
         Parameters
         ----------
-        index : :class:`int`
-            Index of :attr:`__mob_arr` to animate.
+        index
+            Specifies the index of the element who's index mobject animate.
 
         Returns
         -------
         :class:`_AnimationBuilder`
-            Value returned by :meth:`manim.Text.animate` property of :class:`manim.Text`.
+            Animate property of :class:`~manim.mobject.text.text_mobject.Text`.
         """
 
         if index < 0 or index > len(self.__mob_arr):
@@ -1342,43 +1386,43 @@ class MArray(VGroup):
 
     def append_elem(
         self,
-        value,
+        value: Any,
         append_anim: Animation = Write,
         append_anim_args: dict = {},
         append_anim_target: MArrayElementComp = None,
-        play_anim: bool = True,
-        play_anim_args: dict = {},
         mob_square_args: dict = {},
         mob_value_args: dict = {},
         mob_index_args: dict = {},
+        play_anim: bool = True,
+        play_anim_args: dict = {},
     ) -> typing.List[Animation]:
-        """Appends the `value` to :attr:`__arr` and creates a new :class:`MArrayElement` and appends it to :attr:`__mob_arr`.
+        """Creates and inserts a new element in the array.
 
         Parameters
         ----------
         value
-            Value to append.
-        append_anim : :class:`manim.Animation`, default: :class:`manim.Write`
-            Specifies the :class:`manim.Animation` to be played on the :class:`MArrayElement` being appended.
-        append_anim_args : :class:`dict`, default: `{}`
-            Arguments for append :class:`manim.Animation`.
-        append_anim_target : :class:`.m_enum.MArrayElementComp`, default: `None`
-            Specifies the :class:`manim.Mobject` of the :class:`MArrayElement` on which the append :class:`manim.Animation` is to be played.
-        play_anim : :class:`bool`, default: `True`
-            Specifies whether to play the :class:`manim.Animation`.
-        play_anim_args : :class:`dict, default: `{}`
-            Arguments for :meth:`manim.Scene.play`.
-        mob_square_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Square` that represents the element body of :class:`MArrayElement`.
-        mob_value_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element value of :class:`MArrayElement`.
-        mob_index_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element index of :class:`MArrayElement`.
+            Specifies the value of the new element.
+        append_anim
+            Animation to be applied to the new element.
+        append_anim_args
+            Arguments for append :class:`~manim.animation.animation.Animation`.
+        append_anim_target
+            Specifies the target :class:`~manim.mobject.mobject.Mobject` of the :class:`MArrayElement` on which the append :class:`~manim.animation.animation.Animation` is to be played.
+        mob_square_args
+            Arguments for :class:`~manim.mobject.geometry.polygram.Square` that represents the element body.
+        mob_value_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element value.
+        mob_index_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element index.
+        play_anim
+            If `True`, plays the animation(s).
+        play_anim_args
+            Arguments for :py:meth:`Scene.play() <manim.scene.scene.Scene.play>`.
 
         Returns
         -------
-        List[:class:`manim.Animation`]
-            List of animations for appending.
+        :class:`typing.List`\0[:class:`~manim.animation.animation.Animation`]
+            List of append animations.
         """
 
         self.__arr.append(value)
@@ -1400,7 +1444,7 @@ class MArray(VGroup):
 
     def remove_elem(
         self,
-        index,
+        index: int,
         removal_anim: Animation = FadeOut,
         update_anim: Animation = Indicate,
         removal_anim_args: dict = {},
@@ -1410,35 +1454,35 @@ class MArray(VGroup):
         play_anim: bool = True,
         play_anim_args: dict = {},
     ) -> typing.Tuple[Succession, typing.Callable[[bool], typing.List[Animation]]]:
-        """Removes the element from :attr:`__arr` and removes :class:`MArrayElement` from :attr:`__mob_arr` at the specified index.
+        """Removes the element from the array at the specified index.
 
         Parameters
         ----------
-        index : :class:`int`
-            Index of :class:`MArrayElement` to remove.
-        removal_anim : :class:`manim.Animation`, default: :class:`manim.FadeOut`
-            Specifies the :class:`manim.Animation` to be played on the :class:`MArrayElement` being removed.
-        update_anim : :class:`manim.Animation`, default: :class:`manim.Indicate`
-            Specifies the :class:`manim.Animation` to be played on the :class:`MArrayElement`(s) after the removed element.
-        removal_anim_args : :class:`dict`, default: `{}`
-            Arguments for removal :class:`manim.Animation`.
-        update_anim_args : :class:`dict`, default: `{}`
-            Arguments for update :class:`manim.Animation`.
-        removal_anim_target : :class:`.m_enum.MArrayElementComp`, default: `None`
-            Specifies the :class:`manim.Mobject` of the :class:`MArrayElement` on which the removal :class:`manim.Animation` is to be played.
-        update_anim_target : :class:`.m_enum.MArrayElementComp`, default: :attr:`.m_enum.MArrayElementComp.INDEX`
-            Specifies the :class:`manim.Mobject` of the :class:`MArrayElement` on which the update :class:`manim.Animation` is to be played.
-        play_anim : :class:`bool`, default: `True`
-            Specifies whether to play the :class:`manim.Animation`.
-        play_anim_args : :class:`dict, default: `{}`
-            Arguments for :meth:`manim.Scene.play`.
+        index
+            Specifies the index of the element to remove.
+        removal_anim
+            Animation to be applied to the element being removed.
+        update_anim
+            Animation to be applied on remaining elements.
+        removal_anim_args
+            Arguments for removal :class:`~manim.animation.animation.Animation`.
+        update_anim_args
+            Arguments for update :class:`~manim.animation.animation.Animation`.
+        removal_anim_target
+            Specifies the target :class:`~manim.mobject.mobject.Mobject` of the :class:`MArrayElement` on which the removal :class:`~manim.animation.animation.Animation` is to be played.
+        update_anim_target
+            Specifies the target :class:`~manim.mobject.mobject.Mobject` of the :class:`MArrayElement` on which the update :class:`~manim.animation.animation.Animation` is to be played.
+        play_anim
+            If `True`, plays the animation(s).
+        play_anim_args
+            Arguments for :py:meth:`Scene.play() <manim.scene.scene.Scene.play>`.
 
         Returns
         -------
-        :class:`manim.Succession`
-            Contains :class:`manim.Animations` played for removal and shifting of :class:`MArrayElement`.
-        Callable[[bool], List[:class:`manim.Animation`]]
-            Method that updates the indices of :class:`MArrayElement`(s) that occur after the removal and returns a list of update :class:`manim.Animation`(s).
+        :class:`~manim.animation.composition.Succession`
+            Contains :class:`~manim.animation.animation.Animation` played for removal and shifting of element(s).
+        :data:`~typing.Callable`\0[[:class:`bool`], :class:`~typing.List`\0[:class:`~manim.animation.animation.Animation`]]
+            Method that updates the indices of element(s) after the removed element and returns a list of update :class:`~manim.animation.animation.Animation`\0(s).
         """
 
         if index < 0 or index > len(self.__mob_arr):
@@ -1461,50 +1505,6 @@ class MArray(VGroup):
             update_indices(play_anim_args=play_anim_args)
 
         return (remove_anim, update_indices)
-
-    def fetch_arr(self) -> list:
-        """Fetches :attr:`__arr`.
-
-        Returns
-        -------
-        :class:`list`
-            Represents the array stored in :attr:`__arr`.
-        """
-
-        return self.__arr
-
-    def fetch_mob_arr(self) -> typing.List[MArrayElement]:
-        """Fetches :attr:`__mob_arr`.
-
-        Returns
-        -------
-        List[:class:`MArrayElement`]
-            Represents the array stored in :attr:`__mob_arr`.
-        """
-
-        return self.__mob_arr
-
-    def fetch_arr_label(self) -> Text:
-        """Fetches the :class:`manim.Text` that represents the array label.
-
-        Returns
-        -------
-        :class:`manim.Text`
-            Represents the array label.
-        """
-
-        return self.__mob_arr_label
-
-    def fetch_arr_dir(self) -> MArrayDirection:
-        """Fetches the :class:`MArrayDirection` that represents the array's growth direction.
-
-        Returns
-        -------
-        :class:`MArrayDirection`
-            Represents the array's growth direction.
-        """
-
-        return self.__arr_dir
 
 
 class MArrayPointer(VGroup):

--- a/src/manim_data_structures/m_array.py
+++ b/src/manim_data_structures/m_array.py
@@ -13,51 +13,61 @@ class MArrayElement(VGroup):
 
     Parameters
     ----------
-    scene : :class:`manim.Scene`
-        The scene where the object should exist.
-    mob_square_args : :class:`dict`, default: `{}`
-        Arguments for :class:`manim.Square` that represents the element body.
-    mob_value_args : :class:`dict`, default: `{}`
-        Arguments for :class:`manim.Text` that represents the element value.
-    mob_index_args : :class:`dict`, default: `{}`
-        Arguments for :class:`manim.Text` that represents the element index.
-    index_pos : :class:`np.ndarray`, default: `UP`
-        Specifies the position of :attr:`__mob_index`
-    index_gap : :class:`float`, default: `0.25`
-        Specifies the distance between :attr:`__mob_square` and :attr:`__mob_index`
-    label_pos : :class:`np.ndarray`, default: `LEFT`
-        Specifies the position of :attr:`__mob_label`
-    label_gap : :class:`float`, default: `0.5`
-        Specifies the distance between :attr:`__mob_square` and :attr:`__mob_label`
-    next_to_mob : :class:`MArrayElement`, default: `None`
-        Specifies placement for :attr:`__mob_square`
-    next_to_dir : :class:`np.ndarray`, default: `RIGHT`
-        Specifies direction of placement for :attr:`__mob_square`
+    scene
+        Specifies the scene where the object is to be rendered.
+    mob_square_args
+        Arguments for :class:`~manim.mobject.geometry.polygram.Square` that represents the element body.
+    mob_value_args
+        Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element value.
+    mob_index_args
+        Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element index.
+    mob_label_args
+        Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element label.
+    index_pos
+        Specifies the position of :attr:`__mob_index` w.r.t :attr:`__mob_square`
+    index_gap
+        Specifies the distance between :attr:`__mob_index` and :attr:`__mob_square`.
+    label_pos
+        Specifies the position of :attr:`__mob_label` w.r.t :attr:`__mob_square`.
+    label_gap
+        Specifies the distance between :attr:`__mob_label` and :attr:`__mob_square`.
+    next_to_mob
+        Specifies placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
+    next_to_dir
+        Specifies direction of placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
 
     Attributes
     ----------
-    __scene : :class:`manim.Scene`
-        The scene where the object should exist.
-    __mob_square_props : :class:`dict`
-        Default arguments passed to :class:`manim.Square` that represents the element body.
-    __mob_value_props : :class:`dict`
-        Default arguments passed to :class:`manim.Text` that represents the element value.
-    __mob_index_props : :class:`dict`
-        Default arguments passed to :class:`manim.Text` that represents the element index.
-    __mob_square : :class:`manim.Square`
-        :class:`manim.Mobject` that represents the element body.
-    __mob_value : :class:`manim.Text`
-        :class:`manim.Mobject` that represents the element index.
-    __mob_index : :class:`manim.Text`
-        :class:`manim.Mobject` that represents the element value.
+    __scene : :class:`~manim.scene.scene.Scene`
+        Specifies the scene where the object is to be rendered.
+    __mob_square_args : :class:`dict`
+        Arguments for :class:`~manim.mobject.geometry.polygram.Square` that represents the element body.
+    __mob_value_args : :class:`dict`
+        Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element value.
+    __mob_index_args : :class:`dict`
+        Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element index.
+    __mob_label_args : :class:`dict`
+        Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element label.
     __index_pos : :class:`np.ndarray`
-        Specifies the position of :attr:`__mob_index`
+        Specifies the position of :attr:`__mob_index` w.r.t :attr:`__mob_square`
     __index_gap : :class:`float`
-        Specifies the distance between :attr:`__mob_square` and :attr:`__mob_index`
+        Specifies the distance between :attr:`__mob_index` and :attr:`__mob_square`.
     __label_pos : :class:`np.ndarray`
-        Specifies the position of :attr:`__mob_label`
+        Specifies the position of :attr:`__mob_label` w.r.t :attr:`__mob_square`.
     __label_gap : :class:`float`
-        Specifies the distance between :attr:`__mob_square` and :attr:`__mob_label`
+        Specifies the distance between :attr:`__mob_label` and :attr:`__mob_square`.
+    __next_to_mob : :class:`MArrayElement`
+        Specifies placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
+    __next_to_dir : :class:`float`
+        Specifies direction of placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
+    __mob_square : :class:`~manim.mobject.geometry.polygram.Square`
+        Represents the body of the element.
+    __mob_value : :class:`~manim.mobject.text.text_mobject.Text`
+        Represents the value of the element.
+    __mob_index : :class:`~manim.mobject.text.text_mobject.Text`
+        Represents the index of the element.
+    __mob_label : :class:`~manim.mobject.text.text_mobject.Text`
+        Represents the label of the element.
     """
 
     def __init_props(
@@ -72,32 +82,32 @@ class MArrayElement(VGroup):
 
         Parameters
         ----------
-        scene : :class:`manim.Scene`
-            The scene where the object should exist.
-        index_pos : :class:`np.ndarray`
-            Specifies the position of :attr:`__mob_index`
-        index_gap : :class:`float`
-            Specifies the distance between :attr:`__mob_square` and :attr:`__mob_index`
-        label_pos : :class:`np.ndarray`
-            Specifies the position of :attr:`__mob_label`
-        label_gap : :class:`float`
-            Specifies the distance between :attr:`__mob_square` and :attr:`__mob_label`
+        scene
+            Specifies the scene where the object is to be rendered.
+        index_pos
+            Specifies the position of :attr:`__mob_index` w.r.t :attr:`__mob_square`
+        index_gap
+            Specifies the distance between :attr:`__mob_index` and :attr:`__mob_square`.
+        label_pos
+            Specifies the position of :attr:`__mob_label` w.r.t :attr:`__mob_square`.
+        label_gap
+            Specifies the distance between :attr:`__mob_label` and :attr:`__mob_square`.
         """
 
-        self.__mob_square_props = {
+        self.__mob_square_props: dict = {
             "color": BLUE_B,
             "fill_color": BLUE_D,
             "fill_opacity": 1,
             "side_length": 1,
         }
-        self.__mob_value_props = {"text": "", "color": WHITE, "weight": BOLD}
-        self.__mob_index_props = {"text": "", "color": BLUE_D, "font_size": 32}
-        self.__mob_label_props = {"text": "", "color": BLUE_A, "font_size": 38}
-        self.__scene = scene
-        self.__index_pos = index_pos
-        self.__index_gap = index_gap
-        self.__label_pos = label_pos
-        self.__label_gap = label_gap
+        self.__mob_value_props: dict = {"text": "", "color": WHITE, "weight": BOLD}
+        self.__mob_index_props: dict = {"text": "", "color": BLUE_D, "font_size": 32}
+        self.__mob_label_props: dict = {"text": "", "color": BLUE_A, "font_size": 38}
+        self.__scene: Scene = scene
+        self.__index_pos: np.ndarray = index_pos
+        self.__index_gap: float = index_gap
+        self.__label_pos: np.ndarray = label_pos
+        self.__label_gap: float = label_gap
 
     def __update_props(
         self,
@@ -110,14 +120,14 @@ class MArrayElement(VGroup):
 
         Parameters
         ----------
-        mob_square_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Square` that represents the element body.
-        mob_value_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element value.
-        mob_index_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element index.
-        mob_label_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element label.
+        mob_square_args
+            Arguments for :class:`~manim.mobject.geometry.polygram.Square` that represents the element body.
+        mob_value_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element value.
+        mob_index_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element index.
+        mob_label_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element label.
         """
 
         self.__mob_square_props.update(mob_square_args)
@@ -143,26 +153,26 @@ class MArrayElement(VGroup):
         next_to_mob: "MArrayElement" = None,
         next_to_dir: np.ndarray = RIGHT,
     ) -> None:
-        """Initializes the :class:`Mobject`s for the class.
+        """Initializes the mobjects for the class.
 
         Parameters
         ----------
-        init_square : :class:`bool`, default: `False`
-            Instantiates a :class:`manim.Sqaure` and adds it to :attr:`__mob_square`.
-        init_value : :class:`bool`, default: `False`
-            Instantiates a :class:`manim.Text` and adds it to :attr:`__mob_value`.
-        init_index : :class:`bool`, default: `False`
-            Instantiates a :class:`manim.Text` and adds it to :attr:`__mob_index`.
-        init_label : :class:`bool`, default: `False`
-            Instantiates a :class:`manim.Text` and adds it to :attr:`__mob_label`.
-        next_to_mob : :class:`MArrayElement`, default: `None`
-            Specifies placement for :attr:`__mob_square`
-        next_to_dir : :class:`np.ndarray`, default: `RIGHT`
-            Specifies direction of placement for :attr:`__mob_square`
+        init_square
+            If `True`, instantiates a :class:`~manim.mobject.geometry.polygram.Square` and assigns it to :attr:`__mob_square`.
+        init_value
+            If `True`, instantiates a :class:`~manim.mobject.text.text_mobject.Text` and assigns it to :attr:`__mob_value`.
+        init_index
+            If `True`, instantiates a :class:`~manim.mobject.text.text_mobject.Text` and assigns it to :attr:`__mob_index`.
+        init_label
+            If `True`, instantiates a :class:`~manim.mobject.text.text_mobject.Text` and assigns it to :attr:`__mob_label`.
+        next_to_mob
+            Specifies placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
+        next_to_dir
+            Specifies direction of placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
         """
 
         if init_square:
-            self.__mob_square = Square(**self.__mob_square_props)
+            self.__mob_square: Square = Square(**self.__mob_square_props)
             if next_to_mob is not None:
                 self.__mob_square.next_to(
                     next_to_mob.fetch_mob_square(), next_to_dir, 0
@@ -170,19 +180,19 @@ class MArrayElement(VGroup):
             self.add(self.__mob_square)
 
         if init_value:
-            self.__mob_value = Text(**self.__mob_value_props)
+            self.__mob_value: Text = Text(**self.__mob_value_props)
             self.__mob_value.next_to(self.__mob_square, np.array([0, 0, 0]), 0)
             self.add(self.__mob_value)
 
         if init_index:
-            self.__mob_index = Text(**self.__mob_index_props)
+            self.__mob_index: Text = Text(**self.__mob_index_props)
             self.__mob_index.next_to(
                 self.__mob_square, self.__index_pos, self.__index_gap
             )
             self.add(self.__mob_index)
 
         if init_label:
-            self.__mob_label = Text(**self.__mob_label_props)
+            self.__mob_label: Text = Text(**self.__mob_label_props)
             self.__mob_label.next_to(
                 self.__mob_square, self.__label_pos, self.__label_gap
             )
@@ -220,28 +230,28 @@ class MArrayElement(VGroup):
 
         Parameters
         ----------
-        scene : :class:`manim.Scene`
-            The scene where the object should exist.
-        mob_square_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Square` that represents the element body.
-        mob_value_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element value.
-        mob_index_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element index.
-        mob_label_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element label.
-        index_pos : :class:`np.ndarray`, default: `UP`
-            Specifies the position of :attr:`__mob_index`.
-        index_gap : :class:`float`, default: `0.25`
-            Specifies the distance between :attr:`__mob_square` and :attr:`__mob_index`.
-        label_pos : :class:`np.ndarray`, default: `LEFT`
-            Specifies the position of :attr:`__mob_label`.
-        label_gap : :class:`float`, default: `0.5`
-            Specifies the distance between :attr:`__mob_square` and :attr:`__mob_label`
-        next_to_mob : :class:`MArrayElement`, default: `None`
-            Specifies placement for :attr:`__mob_square`.
-        next_to_dir : :class:`np.ndarray`, default: `RIGHT`
-            Specifies direction of placement for :attr:`__mob_square`.
+        scene
+            Specifies the scene where the object is to be rendered.
+        mob_square_args
+            Arguments for :class:`~manim.mobject.geometry.polygram.Square` that represents the element body.
+        mob_value_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element value.
+        mob_index_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element index.
+        mob_label_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element label.
+        index_pos
+            Specifies the position of :attr:`__mob_index` w.r.t :attr:`__mob_square`
+        index_gap
+            Specifies the distance between :attr:`__mob_index` and :attr:`__mob_square`.
+        label_pos
+            Specifies the position of :attr:`__mob_label` w.r.t :attr:`__mob_square`.
+        label_gap
+            Specifies the distance between :attr:`__mob_label` and :attr:`__mob_square`.
+        next_to_mob
+            Specifies placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
+        next_to_dir
+            Specifies direction of placement for :attr:`__mob_square` w.r.t another :class:`MArrayElement`.
         """
 
         super().__init__(**kwargs)
@@ -258,61 +268,61 @@ class MArrayElement(VGroup):
         self.__init_mobs(True, True, True, True, next_to_mob, next_to_dir)
 
     def fetch_mob_square(self) -> Square:
-        """Fetches the :class:`manim.Square` that represents the element body.
+        """Fetches the square mobject.
 
         Returns
         -------
-        :class:`manim.Square`
-            Represents the element body.
+        :class:`~manim.mobject.geometry.polygram.Square`
+            :attr:`__mob_square`.
         """
 
         return self.__mob_square
 
     def fetch_mob_value(self) -> Text:
-        """Fetches the :class:`manim.Text` that represents the element value.
+        """Fetches the value mobject.
 
         Returns
         -------
-        :class:`manim.Text`
-            Represents the element value.
+        :class:`~manim.mobject.text.text_mobject.Text`
+            :attr:`__mob_value`.
         """
 
         return self.__mob_value
 
     def fetch_mob_index(self) -> Text:
-        """Fetches the :class:`manim.Text` that represents the element index.
+        """Fetches the index mobject.
 
         Returns
         -------
-        :class:`manim.Text`
-            Represents the element index.
+        :class:`~manim.mobject.text.text_mobject.Text`
+            :attr:`__mob_index`.
         """
 
         return self.__mob_index
 
     def fetch_mob_label(self) -> Text:
-        """Fetches the :class:`manim.Text` that represents the element label.
+        """Fetches the label mobject.
 
         Returns
         -------
-        :class:`manim.Text`
-            Represents the element label.
+        :class:`~manim.mobject.text.text_mobject.Text`
+            :attr:`__mob_label`.
         """
 
         return self.__mob_label
 
     def fetch_mob(self, mob_target: MArrayElementComp) -> Mobject:
-        """Fetches :class:`manim.Mobject` based on enum :class:`m_enum.MArrayElementComp`.
+        """Fetches the mobject based on the specified enum.
 
         Parameters
         ----------
-        mob_target : :class:`m_enum.MArrayElementComp`
-            Specifies the component of :class:`MArrayElement` to fetch.
+        mob_target
+            Specifies the :class:`~manim.mobject.mobject.Mobject` to fetch.
 
         Returns
         -------
-        :class:`manim.Mobject`
-            Represents the component of :class:`MArrayElement`.
+        :class:`~manim.mobject.mobject.Mobject`
+            Mobject of the class.
         """
 
         if mob_target == MArrayElementComp.BODY:
@@ -334,25 +344,25 @@ class MArrayElement(VGroup):
         play_anim: bool = True,
         play_anim_args: dict = {},
     ) -> Text:
-        """Re-intializes the :class:`manim.Text` that represents the element value.
+        """Re-intializes the value mobject.
 
         Parameters
         ----------
-        mob_value_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element value.
-        update_anim : :class:`manim.Animation`, default `manim.Write`
-            Animation to be applied to the updated :class:`manim.Text`.
-        update_anim_args : :class:`dict`, default: `{}`
-            Arguments for update :class:`manim.Animation`.
-        play_anim : :class:`bool`, default: `True`
-            Specifies whether to play the update :class:`manim.Animation`.
-        play_anim_args : :class:`dict, default: `{}`
-            Arguments for :meth:`manim.Scene.play`.
+        mob_value_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element value.
+        update_anim
+            Animation to be applied to the updated :attr:`__mob_value`.
+        update_anim_args
+            Arguments for update :class:`~manim.animation.animation.Animation`.
+        play_anim
+            If `True`, plays the animation(s).
+        play_anim_args
+            Arguments for :meth:`Scene.play <manim.scene.scene.Scene>`.
 
         Returns
         -------
-        :class:`manim.Text`
-            Represents the updated element value.
+        :class:`~manim.mobject.text.text_mobject.Text`
+            Updated :attr:`__mob_value`.
         """
 
         # Update props of mob_value
@@ -383,25 +393,25 @@ class MArrayElement(VGroup):
         play_anim: bool = True,
         play_anim_args: dict = {},
     ) -> Text:
-        """Re-intializes the :class:`manim.Text` that represents the element index.
+        """Re-intializes the index mobject.
 
         Parameters
         ----------
-        mob_index_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element index.
-        update_anim : :class:`manim.Animation`, default `manim.Write`
-            Animation to be applied to the updated :class:`manim.Text`.
-        update_anim_args : :class:`dict`, default: `{}`
-            Arguments for update :class:`manim.Animation`.
-        play_anim : :class:`bool`, default: `True`
-            Specifies whether to play the update :class:`manim.Animation`.
-        play_anim_args : :class:`dict, default: `{}`
-            Arguments for :meth:`manim.Scene.play`.
+        mob_index_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element index.
+        update_anim
+            Animation to be applied to the updated :attr:`__mob_index`.
+        update_anim_args
+            Arguments for update :class:`~manim.animation.animation.Animation`.
+        play_anim
+            If `True`, plays the animation(s).
+        play_anim_args
+            Arguments for :meth:`Scene.play <manim.scene.scene.Scene>`.
 
         Returns
         -------
-        :class:`manim.Text`
-            Represents the updated element index.
+        :class:`~manim.mobject.text.text_mobject.Text`
+            Updated :attr:`__mob_index`.
         """
 
         # Update props of mob_index
@@ -432,25 +442,25 @@ class MArrayElement(VGroup):
         play_anim: bool = True,
         play_anim_args: dict = {},
     ) -> Text:
-        """Re-intializes the :class:`manim.Text` that represents the element label.
+        """Re-intializes the label mobject.
 
         Parameters
         ----------
-        mob_label_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element label.
-        update_anim : :class:`manim.Animation`, default `manim.Write`
-            Animation to be applied to the updated :class:`manim.Text`.
-        update_anim_args : :class:`dict`, default: `{}`
-            Arguments for update :class:`manim.Animation`.
-        play_anim : :class:`bool`, default: `True`
-            Specifies whether to play the update :class:`manim.Animation`.
-        play_anim_args : :class:`dict, default: `{}`
-            Arguments for :meth:`manim.Scene.play`.
+        mob_label_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the element label.
+        update_anim
+            Animation to be applied to the updated :attr:`__mob_label`.
+        update_anim_args
+            Arguments for update :class:`~manim.animation.animation.Animation`.
+        play_anim
+            If `True`, plays the animation(s).
+        play_anim_args
+            Arguments for :meth:`Scene.play <manim.scene.scene.Scene>`.
 
         Returns
         -------
-        :class:`manim.Text`
-            Represents the updated element label.
+        :class:`~manim.mobject.text.text_mobject.Text`
+            Updated :attr:`__mob_label`.
         """
 
         # Update props of mob_label
@@ -474,45 +484,45 @@ class MArrayElement(VGroup):
         return self.__mob_label
 
     def animate_mob_square(self) -> "_AnimationBuilder":  # type: ignore
-        """Invokes the :meth:`manim.Square.animate` property of :class:`manim.Square` for the element body.
+        """Invokes the animate property over square mobject.
 
         Returns
         -------
         :class:`_AnimationBuilder`
-            Value returned by :meth:`manim.Square.animate` property of :class:`manim.Square`.
+            Animate property of :attr:`__mob_square`.
         """
 
         return self.__mob_square.animate
 
     def animate_mob_value(self) -> "_AnimationBuilder":  # type: ignore
-        """Invokes the :meth:`manim.Text.animate` property of :class:`manim.Text` for the element value.
+        """Invokes the animate property over value mobject.
 
         Returns
         -------
         :class:`_AnimationBuilder`
-            Value returned by :meth:`manim.Text.animate` property of :class:`manim.Text`.
+            Animate property of :attr:`__mob_value`.
         """
 
         return self.__mob_value.animate
 
     def animate_mob_index(self) -> "_AnimationBuilder":  # type: ignore
-        """Invokes the :meth:`manim.Text.animate` property of :class:`manim.Text` for the element index.
+        """Invokes the animate property over index mobject.
 
         Returns
         -------
         :class:`_AnimationBuilder`
-            Value returned by :meth:`manim.Text.animate` property of :class:`manim.Text`.
+            Animate property of :attr:`__mob_index`.
         """
 
         return self.__mob_index.animate
 
     def animate_mob_label(self) -> "_AnimationBuilder":  # type: ignore
-        """Invokes the :meth:`manim.Text.animate` property of :class:`manim.Text` for the element label.
+        """Invokes the animate property over label mobject.
 
         Returns
         -------
         :class:`_AnimationBuilder`
-            Value returned by :meth:`manim.Text.animate` property of :class:`manim.Text`.
+            Animate property of :attr:`__mob_label`.
         """
 
         return self.__mob_label.animate

--- a/src/manim_data_structures/m_array.py
+++ b/src/manim_data_structures/m_array.py
@@ -357,7 +357,7 @@ class MArrayElement(VGroup):
         play_anim
             If `True`, plays the animation(s).
         play_anim_args
-            Arguments for :meth:`Scene.play <manim.scene.scene.Scene>`.
+            Arguments for :py:meth:`Scene.play() <manim.scene.scene.Scene.play>`.
 
         Returns
         -------
@@ -406,7 +406,7 @@ class MArrayElement(VGroup):
         play_anim
             If `True`, plays the animation(s).
         play_anim_args
-            Arguments for :meth:`Scene.play <manim.scene.scene.Scene>`.
+            Arguments for :py:meth:`Scene.play() <manim.scene.scene.Scene.play>`.
 
         Returns
         -------
@@ -455,7 +455,7 @@ class MArrayElement(VGroup):
         play_anim
             If `True`, plays the animation(s).
         play_anim_args
-            Arguments for :meth:`Scene.play <manim.scene.scene.Scene>`.
+            Arguments for :py:meth:`Scene.play() <manim.scene.scene.Scene.play>`.
 
         Returns
         -------

--- a/src/manim_data_structures/m_enum.py
+++ b/src/manim_data_structures/m_enum.py
@@ -4,23 +4,23 @@ from enum import Enum
 
 
 class MArrayElementComp(Enum):
-    """Refers to the individual component :class:`manim.Mobject` of :class:`MArrayElement`."""
+    """Refers to individual component :class:`~manim.mobject.mobject.Mobject`\0s of :class:`~.m_array.MArrayElement`."""
 
     BODY = 0
-    """Body :class:`manim.Square`"""
+    """:class:`~manim.mobject.geometry.polygram.Square` that represents the body."""
 
     VALUE = 1
-    """Value :class:`manim.Text`"""
+    """:class:`~manim.mobject.text.text_mobject.Text` that represents the value."""
 
     INDEX = 2
-    """Index :class:`manim.Text`"""
+    """:class:`~manim.mobject.text.text_mobject.Text` that represents the index."""
 
     LABEL = 3
-    """Label :class:`manim.Text`"""
+    """:class:`~manim.mobject.text.text_mobject.Text` that represents the label."""
 
 
 class MArrayDirection(Enum):
-    """Specifies the growth direction of the :class:`MArray`."""
+    """Serves as the direction for :class:`~.m_array.MArray`."""
 
     UP = 0
     """Upward direction."""

--- a/src/manim_data_structures/m_variable.py
+++ b/src/manim_data_structures/m_variable.py
@@ -149,7 +149,7 @@ class MVariable(MArrayElement):
         play_anim
             Specifies whether to play the :class:`~manim.animation.animation.Animation`.
         play_anim_args
-            Arguments for :meth:`Scene.play <~manim.scene.scene.Scene.play>`.
+            Arguments for :py:meth:`Scene.play() <manim.scene.scene.Scene.play>`.
 
         Returns
         -------
@@ -187,7 +187,7 @@ class MVariable(MArrayElement):
         play_anim
             Specifies whether to play the :class:`~manim.animation.animation.Animation`.
         play_anim_args
-            Arguments for :meth:`Scene.play <~manim.scene.scene.Scene.play>`.
+            Arguments for :py:meth:`Scene.play() <manim.scene.scene.Scene.play>`.
 
         Returns
         -------
@@ -225,7 +225,7 @@ class MVariable(MArrayElement):
         play_anim
             Specifies whether to play the :class:`~manim.animation.animation.Animation`.
         play_anim_args
-            Arguments for :meth:`Scene.play <~manim.scene.scene.Scene.play>`.
+            Arguments for :py:meth:`Scene.play() <manim.scene.scene.Scene.play>`.
 
         Returns
         -------

--- a/src/manim_data_structures/m_variable.py
+++ b/src/manim_data_structures/m_variable.py
@@ -33,7 +33,7 @@ class MVariable(MArrayElement):
     ----------
     __value : Any
         The value of the variable.
-    __index : Union[:class:`str`, :class:`int`]
+    __index : :data:`~typing.Union`\0[:class:`str`, :class:`int`]
         The value of the index.
     __label : :class:`str`
         The value of the label.
@@ -108,7 +108,7 @@ class MVariable(MArrayElement):
 
         Returns
         -------
-        Union[:class:`str`, :class:`int`]
+        :data:`~typing.Union`\0[:class:`str`, :class:`int`]
             :attr:`__index`.
         """
 

--- a/src/manim_data_structures/m_variable.py
+++ b/src/manim_data_structures/m_variable.py
@@ -10,39 +10,41 @@ class MVariable(MArrayElement):
 
     Parameters
     ----------
-    scene : :class:`manim.Scene`
-        The scene where the object should exist.
+    scene
+        Specifies the scene where the object is to be rendered.
     value
         Specifies the value of the variable.
     index
         Specifies the index of the variable.
     label
         Specifies the label of the variable.
-    mob_square_args : :class:`dict`, default: `{}`
-        Arguments for :class:`manim.Square` that represents the element body.
-    mob_value_args : :class:`dict`, default: `{}`
-        Arguments for :class:`manim.Text` that represents the element value.
-    mob_index_args : :class:`dict`, default: `{}`
-        Arguments for :class:`manim.Text` that represents the element index.
-    mob_label_args : :class:`dict`, default: `{}`
-        Arguments for :class:`manim.Text` that represents the element label.
+    mob_square_args
+        Arguments for :class:`~manim.mobject.geometry.polygram.Square` that represents the variable body.
+    mob_value_args
+        Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the variable value.
+    mob_index_args
+        Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the variable index.
+    mob_label_args
+        Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the variable label.
+    **kwargs
+        Forwarded to constructor of the parent.
 
     Attributes
     ----------
-    __value
-        Specifies the value of the variable.
-    __index
-        Specifies the index of the variable.
-    __label
-        Specifies the label of the variable.
+    __value : Any
+        The value of the variable.
+    __index : Union[:class:`str`, :class:`int`]
+        The value of the index.
+    __label : :class:`str`
+        The value of the label.
     """
 
     def __init__(
         self,
         scene: Scene,
-        value="",
-        index="",
-        label="",
+        value: Any = "",
+        index: typing.Union[str, int] = "",
+        label: str = "",
         mob_square_args: dict = {},
         mob_value_args: dict = {},
         mob_index_args: dict = {},
@@ -53,27 +55,29 @@ class MVariable(MArrayElement):
 
         Parameters
         ----------
-        scene : :class:`manim.Scene`
-            The scene where the object should exist.
+        scene
+            Specifies the scene where the object is to be rendered.
         value
             Specifies the value of the variable.
         index
             Specifies the index of the variable.
         label
             Specifies the label of the variable.
-        mob_square_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Square` that represents the element body.
-        mob_value_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element value.
-        mob_index_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element index.
-        mob_label_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element label.
+        mob_square_args
+            Arguments for :class:`~manim.mobject.geometry.polygram.Square` that represents the variable body.
+        mob_value_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the variable value.
+        mob_index_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the variable index.
+        mob_label_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the variable label.
+        **kwargs
+            Forwarded to constructor of the parent.
         """
 
-        self.__value = value
-        self.__index = index
-        self.__label = label
+        self.__value: Any = value
+        self.__index: typing.Union[str, int] = index
+        self.__label: str = label
 
         mob_value_args["text"] = value
         mob_index_args["text"] = index
@@ -88,134 +92,149 @@ class MVariable(MArrayElement):
             **kwargs
         )
 
-    def fetch_value(self):
-        """Fetches :attr:`__value`.
+    def fetch_value(self) -> Any:
+        """Fetches the value of the variable.
 
         Returns
         -------
         Any
-            Value of :class:`MVariable`.
+            :attr:`__value`.
         """
 
         return self.__value
 
-    def fetch_index(self):
-        """Fetches :attr:`__index`.
+    def fetch_index(self) -> typing.Union[str, int]:
+        """Fetches the index of the variable.
 
         Returns
         -------
-        Any
-            Index of :class:`MVariable`.
+        Union[:class:`str`, :class:`int`]
+            :attr:`__index`.
         """
 
         return self.__index
 
-    def fetch_label(self):
-        """Fetches :attr:`__label`.
+    def fetch_label(self) -> str:
+        """Fetches the label of the variable.
 
         Returns
         -------
-        Any
-            Label of :class:`MVariable`.
+        :class:`str`
+            :attr:`__label`.
         """
 
         return self.__label
 
     def update_value(
         self,
-        value,
+        value: Any,
         mob_value_args: dict = {},
         update_anim: Animation = Indicate,
         update_anim_args: dict = {},
         play_anim: bool = True,
+        play_anim_args: dict = {},
     ) -> Text:
-        """Updates :attr:`__value` and the :class:`manim.Text` that represents the element value.
+        """Updates the value of the variable.
 
         Parameters
         ----------
-        mob_value_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element value.
-        update_anim : :class:`manim.Animation`, default `{manim.Indicate}`
-            Animation to be applied to the updated :class:`manim.Text`.
-        update_anim_args : :class:`dict`, default: `{}`
-            Arguments for update :class:`manim.Animation`.
-        play_anim : :class:`bool`, default: `True`
-            Specifies whether to play the update :class:`manim.Animation`.
+        value
+            New value to be assigned to the variable.
+        mob_value_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the variable value.
+        update_anim
+            Animation to be applied to the updated :class:`~manim.mobject.text.text_mobject.Text`.
+        update_anim_args
+            Arguments for the update :class:`~manim.animation.animation.Animation`.
+        play_anim
+            Specifies whether to play the :class:`~manim.animation.animation.Animation`.
+        play_anim_args
+            Arguments for :meth:`Scene.play <~manim.scene.scene.Scene.play>`.
 
         Returns
         -------
-        :class:`manim.Text`
-            Represents the updated element value.
+        :class:`~manim.mobject.text.text_mobject.Text`
+            Updated :attr:`__value`.
         """
 
         self.__value = value
         mob_value_args["text"] = value
         return self.update_mob_value(
-            mob_value_args, update_anim, update_anim_args, play_anim
+            mob_value_args, update_anim, update_anim_args, play_anim, play_anim_args
         )
 
     def update_index(
         self,
-        index,
+        index: typing.Union[str, int],
         mob_index_args: dict = {},
         update_anim: Animation = Indicate,
         update_anim_args: dict = {},
         play_anim: bool = True,
+        play_anim_args: dict = {},
     ) -> Text:
-        """Updates :attr:`__index` and the :class:`manim.Text` that represents the element index.
+        """Updates the index of the variable.
 
         Parameters
         ----------
-        mob_index_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element index.
-        update_anim : :class:`manim.Animation`, default `{manim.Indicate}`
-            Animation to be applied to the updated :class:`manim.Text`.
-        update_anim_args : :class:`dict`, default: `{}`
-            Arguments for update :class:`manim.Animation`.
-        play_anim : :class:`bool`, default: `True`
-            Specifies whether to play the update :class:`manim.Animation`.
+        index
+            New index to be assigned to the variable.
+        mob_index_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the variable index.
+        update_anim
+            Animation to be applied to the updated :class:`~manim.mobject.text.text_mobject.Text`.
+        update_anim_args
+            Arguments for the update :class:`~manim.animation.animation.Animation`.
+        play_anim
+            Specifies whether to play the :class:`~manim.animation.animation.Animation`.
+        play_anim_args
+            Arguments for :meth:`Scene.play <~manim.scene.scene.Scene.play>`.
 
         Returns
         -------
-        :class:`manim.Text`
-            Represents the updated element index.
+        :class:`~manim.mobject.text.text_mobject.Text`
+            Updated :attr:`__index`.
         """
 
         self.__index = index
         mob_index_args["text"] = index
         return self.update_mob_index(
-            mob_index_args, update_anim, update_anim_args, play_anim
+            mob_index_args, update_anim, update_anim_args, play_anim, play_anim_args
         )
 
     def update_label(
         self,
-        label,
+        label: str,
         mob_label_args: dict = {},
         update_anim: Animation = Indicate,
         update_anim_args: dict = {},
         play_anim: bool = True,
+        play_anim_args: dict = {},
     ) -> Text:
-        """Updates :attr:`__label` and the :class:`manim.Text` that represents the element label.
+        """Updates the label of the variable.
 
         Parameters
         ----------
-        mob_label_args : :class:`dict`, default: `{}`
-            Arguments for :class:`manim.Text` that represents the element label.
-        update_anim : :class:`manim.Animation`, default `{manim.Indicate}`
-            Animation to be applied to the updated :class:`manim.Text`.
-        update_anim_args : :class:`dict`, default: `{}`
-            Arguments for update :class:`manim.Animation`.
-        play_anim : :class:`bool`, default: `True`
-            Specifies whether to play the update :class:`manim.Animation`.
+        label
+            New label to be assigned to the variable.
+        mob_value_args
+            Arguments for :class:`~manim.mobject.text.text_mobject.Text` that represents the label value.
+        update_anim
+            Animation to be applied to the updated :class:`~manim.mobject.text.text_mobject.Text`.
+        update_anim_args
+            Arguments for the update :class:`~manim.animation.animation.Animation`.
+        play_anim
+            Specifies whether to play the :class:`~manim.animation.animation.Animation`.
+        play_anim_args
+            Arguments for :meth:`Scene.play <~manim.scene.scene.Scene.play>`.
 
         Returns
         -------
-        :class:`manim.Text`
-            Represents the updated element label.
+        :class:`~manim.mobject.text.text_mobject.Text`
+            Updated :attr:`__label`.
         """
 
         self.__value = label
         mob_label_args["text"] = label
         return self.update_mob_label(
-            mob_label_args, update_anim, update_anim_args, play_anim
+            mob_label_args, update_anim, update_anim_args, play_anim, play_anim_args
         )


### PR DESCRIPTION
<!-- Thank you for contributing to Manim Data Structures! Learn more about the process in our contributing guidelines: https://github.com/drageelr/manim-data-structures/blob/main/CONTRIBUTING.md -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->

* Following sphinx extensions are added and configured:
  * `intersphinx`: Configured for `python`, `manim` and `numpy`.
  * `napolean`
  * `sphinx_autodoc_typehints`
* Created a substitution reference file `refsub.rst` for code element references.
* Updated "Animating Arrays" guide in accordance with `refsub.rst`.
* Docstrings for the following classes updated:
  * `MArrayElement`
  * `MArray`
  * `MArrayPointer`
  * `MVariable`
  * `MArrayElementComp`
  * `MArrayDirection`

<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->

* References to other library documentations is enabled.
* Aggregated references used in the documentation in a single file and utilized them in other doc pages to reduce clutter.
* Simplified and unified docstrings for all classes.

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [x] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [x] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
